### PR TITLE
Add monthly attendance recap

### DIFF
--- a/app/Exports/RekapAbsensiExport.php
+++ b/app/Exports/RekapAbsensiExport.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Exports;
+
+use App\Models\Siswa;
+use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\WithHeadings;
+
+class RekapAbsensiExport implements FromCollection, WithHeadings
+{
+    protected $bulan;
+    protected $tahun;
+    protected $kelas;
+
+    public function __construct($bulan, $tahun, $kelas = null)
+    {
+        $this->bulan = $bulan;
+        $this->tahun = $tahun;
+        $this->kelas = $kelas;
+    }
+
+    public function collection()
+    {
+        $siswaQuery = Siswa::query();
+        if ($this->kelas) {
+            $siswaQuery->where('kelas', $this->kelas);
+        }
+
+        $rekap = $siswaQuery->withCount([
+            'absensi as hadir' => function ($q) {
+                $q->where('status', 'Hadir')
+                  ->whereMonth('tanggal', $this->bulan)
+                  ->whereYear('tanggal', $this->tahun);
+            },
+            'absensi as izin' => function ($q) {
+                $q->where('status', 'Izin')
+                  ->whereMonth('tanggal', $this->bulan)
+                  ->whereYear('tanggal', $this->tahun);
+            },
+            'absensi as sakit' => function ($q) {
+                $q->where('status', 'Sakit')
+                  ->whereMonth('tanggal', $this->bulan)
+                  ->whereYear('tanggal', $this->tahun);
+            },
+            'absensi as alpha' => function ($q) {
+                $q->where('status', 'Alpha')
+                  ->whereMonth('tanggal', $this->bulan)
+                  ->whereYear('tanggal', $this->tahun);
+            },
+        ])->get();
+
+        return $rekap->map(function ($s) {
+            return [
+                'Nama' => $s->nama,
+                'Kelas' => $s->kelas,
+                'Hadir' => $s->hadir,
+                'Izin' => $s->izin,
+                'Sakit' => $s->sakit,
+                'Alpha' => $s->alpha,
+            ];
+        });
+    }
+
+    public function headings(): array
+    {
+        return ['Nama', 'Kelas', 'Hadir', 'Izin', 'Sakit', 'Alpha'];
+    }
+}

--- a/app/Models/Siswa.php
+++ b/app/Models/Siswa.php
@@ -11,4 +11,12 @@ class Siswa extends Model
 
     protected $table = 'siswa';
     protected $fillable = ['nama', 'kelas', 'tanggal_lahir'];
+
+    /**
+     * Relasi ke tabel absensi.
+     */
+    public function absensi()
+    {
+        return $this->hasMany(Absensi::class);
+    }
 }

--- a/resources/views/absensi/rekap.blade.php
+++ b/resources/views/absensi/rekap.blade.php
@@ -1,0 +1,63 @@
+@extends('layouts.app')
+
+@section('title', 'Rekap Absensi')
+
+@section('content')
+<h1>Rekap Absensi Bulanan</h1>
+<form method="GET" class="row g-2 mb-3">
+    <div class="col-auto">
+        <select name="bulan" class="form-control">
+            @for ($i = 1; $i <= 12; $i++)
+                <option value="{{ $i }}" {{ $i == $bulan ? 'selected' : '' }}>{{ $i }}</option>
+            @endfor
+        </select>
+    </div>
+    <div class="col-auto">
+        <select name="tahun" class="form-control">
+            @for ($y = date('Y') - 1; $y <= date('Y') + 1; $y++)
+                <option value="{{ $y }}" {{ $y == $tahun ? 'selected' : '' }}>{{ $y }}</option>
+            @endfor
+        </select>
+    </div>
+    <div class="col-auto">
+        <select name="kelas" class="form-control">
+            <option value="">-- Semua Kelas --</option>
+            @foreach($kelasList as $k)
+                <option value="{{ $k }}" {{ $kelas == $k ? 'selected' : '' }}>{{ $k }}</option>
+            @endforeach
+        </select>
+    </div>
+    <div class="col-auto">
+        <button class="btn btn-primary">Tampilkan</button>
+    </div>
+    <div class="col-auto">
+        <a class="btn btn-success" href="{{ route('absensi.rekap.export', request()->query()) }}">Download Excel</a>
+    </div>
+</form>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>No</th>
+            <th>Nama</th>
+            <th>Kelas</th>
+            <th>Hadir</th>
+            <th>Izin</th>
+            <th>Sakit</th>
+            <th>Alpha</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach ($rekap as $r)
+        <tr>
+            <td>{{ $loop->iteration }}</td>
+            <td>{{ $r->nama }}</td>
+            <td>{{ $r->kelas }}</td>
+            <td>{{ $r->hadir }}</td>
+            <td>{{ $r->izin }}</td>
+            <td>{{ $r->sakit }}</td>
+            <td>{{ $r->alpha }}</td>
+        </tr>
+        @endforeach
+    </tbody>
+</table>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,6 +27,8 @@ Route::middleware(['auth'])->group(function () {
     Route::resource('mapel', MapelController::class)->except('show');
     Route::resource('nilai', NilaiController::class)->except('show');
     Route::resource('absensi', AbsensiController::class)->except('show');
+    Route::get('/absensi/rekap', [AbsensiController::class, 'rekap'])->name('absensi.rekap');
+    Route::get('/absensi/rekap/export', [AbsensiController::class, 'exportRekap'])->name('absensi.rekap.export');
     
     Route::get('/rapor/{siswa}', [RaporController::class, 'cetak'])->name('rapor.cetak');
     Route::get('/siswa-export', [SiswaController::class, 'export'])->name('siswa.export');

--- a/tests/Feature/AbsensiRekapTest.php
+++ b/tests/Feature/AbsensiRekapTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AbsensiRekapTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_rekap_page_can_be_opened(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('/absensi/rekap');
+
+        $response->assertOk();
+        $response->assertSee('Rekap Absensi');
+    }
+}


### PR DESCRIPTION
## Summary
- relate students to attendance records
- enable rekap absensi per month/year with export
- add RekapAbsensiExport
- add route and view for attendance recap
- test rekap page

## Testing
- `./vendor/bin/phpunit --stop-on-failure` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f0e3a084832b80116d8fcea09415