### PR TITLE
Add monthly absence recap button

### DIFF
--- a/resources/views/absensi/index.blade.php
+++ b/resources/views/absensi/index.blade.php
@@ -5,7 +5,10 @@
 @section('content')
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1>Daftar Absensi</h1>
-    <a href="{{ route('absensi.create') }}" class="btn btn-primary">+ Tambah Absensi</a>
+    <div>
+        <a href="{{ route('absensi.rekap') }}" class="btn btn-secondary me-2">Rekap Bulanan</a>
+        <a href="{{ route('absensi.create') }}" class="btn btn-primary">+ Tambah Absensi</a>
+    </div>
 </div>
 @if(session('success'))
     <div class="alert alert-success">{{ session('success') }}</div>


### PR DESCRIPTION
## Summary
- link monthly attendance recap page from absence list

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6867f4f92e38832bbf81b65d18d5c46e