### PR TITLE
Add dashboard statistics charts

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -6,20 +6,38 @@ use App\Models\Siswa;
 use App\Models\Guru;
 use App\Models\MataPelajaran;
 use App\Models\Absensi;
+use App\Models\Nilai;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class DashboardController extends Controller
 {
     public function index()
     {
-        $today = Carbon::today()->toDateString();
+        $today = Carbon::today();
+
+        $absensiPerHari = Absensi::selectRaw('tanggal, count(*) as total')
+            ->where('status', 'Hadir')
+            ->whereBetween('tanggal', [$today->copy()->subDays(6), $today])
+            ->groupBy('tanggal')
+            ->orderBy('tanggal')
+            ->get();
+
+        $topNilai = Nilai::select('siswa_id', DB::raw('avg(nilai) as rata'))
+            ->groupBy('siswa_id')
+            ->orderByDesc('rata')
+            ->with('siswa')
+            ->take(10)
+            ->get();
 
         return view('dashboard', [
             'totalSiswa' => Siswa::count(),
             'totalGuru' => Guru::count(),
             'totalMapel' => MataPelajaran::count(),
             'totalKelas' => Siswa::select('kelas')->distinct()->count(),
-            'absensiHariIni' => Absensi::where('tanggal', $today)->where('status', 'Hadir')->count(),
+            'absensiHariIni' => Absensi::where('tanggal', $today->toDateString())->where('status', 'Hadir')->count(),
+            'absensiPerHari' => $absensiPerHari,
+            'topNilai' => $topNilai,
         ]);
     }
 }

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -47,6 +47,15 @@
     </div>
 </div>
 
+<div class="row mb-4">
+    <div class="col-md-6">
+        <canvas id="absensiChart"></canvas>
+    </div>
+    <div class="col-md-6">
+        <canvas id="nilaiChart"></canvas>
+    </div>
+</div>
+
 <div class="list-group">
     <a href="{{ route('guru.index') }}" class="list-group-item list-group-item-action">Manajemen Guru</a>
     <a href="{{ route('siswa.index') }}" class="list-group-item list-group-item-action">Manajemen Siswa</a>
@@ -54,4 +63,47 @@
     <a href="{{ route('nilai.index') }}" class="list-group-item list-group-item-action">Nilai Siswa</a>
     <a href="{{ route('absensi.index') }}" class="list-group-item list-group-item-action">Absensi Siswa</a>
 </div>
+@endsection
+
+@section('scripts')
+<script>
+    const absensiLabels = @json($absensiPerHari->pluck('tanggal'));
+    const absensiData = @json($absensiPerHari->pluck('total'));
+    new Chart(document.getElementById('absensiChart'), {
+        type: 'bar',
+        data: {
+            labels: absensiLabels,
+            datasets: [{
+                label: 'Hadir',
+                data: absensiData,
+                backgroundColor: 'rgba(54, 162, 235, 0.5)'
+            }]
+        },
+        options: {
+            scales: {
+                y: { beginAtZero: true }
+            }
+        }
+    });
+
+    const nilaiLabels = @json($topNilai->pluck('siswa.nama'));
+    const nilaiData = @json($topNilai->pluck('rata'));
+    new Chart(document.getElementById('nilaiChart'), {
+        type: 'bar',
+        data: {
+            labels: nilaiLabels,
+            datasets: [{
+                label: 'Rata-rata Nilai',
+                data: nilaiData,
+                backgroundColor: 'rgba(255, 99, 132, 0.5)'
+            }]
+        },
+        options: {
+            indexAxis: 'y',
+            scales: {
+                x: { beginAtZero: true }
+            }
+        }
+    });
+</script>
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -32,5 +32,9 @@
     <div class="container">
         @yield('content')
     </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    @yield('scripts')
 </body>
 </html>


### PR DESCRIPTION
## Summary
- install Chart.js via CDN and add script placeholder
- show attendance per day and top 10 grade charts in dashboard
- compute attendance and grade statistics in `DashboardController`

## Testing
- `npm --version`
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867faf9d4a8832ba41b6bcf92f70747