### PR TITLE
Fix sidebar toggle visibility on desktop

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -8,7 +8,7 @@
 </head>
 <body>
     <!-- Navbar di sini -->
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+    <nav class="navbar navbar-dark bg-dark mb-4">
         <div class="container">
             @auth
             <button class="navbar-toggler me-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebar" aria-controls="sidebar">


### PR DESCRIPTION
## Summary
- keep sidebar toggle visible on all screen sizes by removing `navbar-expand-lg`

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867fee4b204832b84213ce8f34a737f