### PR TITLE
Improve seeder names

### DIFF
--- a/database/seeders/GuruSeeder.php
+++ b/database/seeders/GuruSeeder.php
@@ -4,16 +4,18 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Faker\Factory as Faker;
 
 class GuruSeeder extends Seeder
 {
     public function run(): void
     {
+        $faker = Faker::create('id_ID');
         $data = [];
         for ($i = 1; $i <= 20; $i++) {
             $data[] = [
                 'nip' => str_pad($i, 18, '0', STR_PAD_LEFT),
-                'nama' => 'Guru ' . $i,
+                'nama' => $faker->unique()->name,
             ];
         }
         DB::table('guru')->insert($data);

--- a/database/seeders/MataPelajaranSeeder.php
+++ b/database/seeders/MataPelajaranSeeder.php
@@ -9,9 +9,21 @@ class MataPelajaranSeeder extends Seeder
 {
     public function run(): void
     {
+        $mapel = [
+            'Matematika',
+            'Bahasa Indonesia',
+            'Bahasa Inggris',
+            'Kimia',
+            'Fisika',
+            'Biologi',
+            'Ekonomi',
+            'Sejarah',
+            'Geografi',
+            'Seni Budaya',
+        ];
         $data = [];
-        for ($i = 1; $i <= 10; $i++) {
-            $data[] = ['nama' => 'Mapel ' . $i];
+        foreach ($mapel as $nama) {
+            $data[] = ['nama' => $nama];
         }
         DB::table('mata_pelajaran')->insert($data);
     }

--- a/database/seeders/SiswaSeeder.php
+++ b/database/seeders/SiswaSeeder.php
@@ -4,17 +4,19 @@ namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
+use Faker\Factory as Faker;
 
 class SiswaSeeder extends Seeder
 {
     public function run(): void
     {
+        $faker = Faker::create('id_ID');
         $data = [];
         for ($i = 1; $i <= 50; $i++) {
             $data[] = [
-                'nama' => 'Siswa ' . $i,
+                'nama' => $faker->unique()->name,
                 'kelas' => '10' . chr(64 + ($i % 3) + 1),
-                'tanggal_lahir' => '2008-' . str_pad(rand(1, 12), 2, '0', STR_PAD_LEFT) . '-' . str_pad(rand(1, 28), 2, '0', STR_PAD_LEFT),
+                'tanggal_lahir' => $faker->dateTimeBetween('2008-01-01', '2008-12-31')->format('Y-m-d'),
             ];
         }
         DB::table('siswa')->insert($data);


### PR DESCRIPTION
## Summary
- use Faker to generate realistic student and teacher names
- add subject names instead of generic numbering

## Testing
- `php artisan test` *(fails: `php` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686804f28708832ba5fdc905e2904d80