### PR TITLE
Implement role based access control

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -40,6 +40,7 @@ class RegisteredUserController extends Controller
             'name' => $request->name,
             'email' => $request->email,
             'password' => Hash::make($request->password),
+            'role' => 'siswa',
         ]);
 
         event(new Registered($user));

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -63,5 +63,6 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'role' => \App\Http\Middleware\RoleMiddleware::class,
     ];
 }

--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RoleMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  mixed ...$roles
+     * @return Response
+     */
+    public function handle(Request $request, Closure $next, ...$roles)
+    {
+        $user = $request->user();
+        if (!$user || !in_array($user->role, $roles)) {
+            abort(403);
+        }
+        return $next($request);
+    }
+}
+

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
     ];
 
     /**

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -46,21 +46,23 @@
                 <a href="{{ route('dashboard') }}" class="list-group-item list-group-item-action">
                     <i class="bi bi-speedometer2 me-2"></i>Dashboard
                 </a>
-                <a href="{{ route('guru.index') }}" class="list-group-item list-group-item-action">
-                    <i class="bi bi-person-badge me-2"></i>Manajemen Guru
-                </a>
-                <a href="{{ route('siswa.index') }}" class="list-group-item list-group-item-action">
-                    <i class="bi bi-people me-2"></i>Manajemen Siswa
-                </a>
-                <a href="{{ route('mapel.index') }}" class="list-group-item list-group-item-action">
-                    <i class="bi bi-book me-2"></i>Manajemen Mapel
-                </a>
-                <a href="{{ route('nilai.index') }}" class="list-group-item list-group-item-action">
-                    <i class="bi bi-card-checklist me-2"></i>Nilai Siswa
-                </a>
-                <a href="{{ route('absensi.index') }}" class="list-group-item list-group-item-action">
-                    <i class="bi bi-person-check me-2"></i>Absensi Siswa
-                </a>
+                @if(Auth::user()->role === 'admin')
+                    <a href="{{ route('guru.index') }}" class="list-group-item list-group-item-action">
+                        <i class="bi bi-person-badge me-2"></i>Manajemen Guru
+                    </a>
+                    <a href="{{ route('siswa.index') }}" class="list-group-item list-group-item-action">
+                        <i class="bi bi-people me-2"></i>Manajemen Siswa
+                    </a>
+                    <a href="{{ route('mapel.index') }}" class="list-group-item list-group-item-action">
+                        <i class="bi bi-book me-2"></i>Manajemen Mapel
+                    </a>
+                    <a href="{{ route('nilai.index') }}" class="list-group-item list-group-item-action">
+                        <i class="bi bi-card-checklist me-2"></i>Nilai Siswa
+                    </a>
+                    <a href="{{ route('absensi.index') }}" class="list-group-item list-group-item-action">
+                        <i class="bi bi-person-check me-2"></i>Absensi Siswa
+                    </a>
+                @endif
             </div>
         </div>
     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,8 +20,8 @@ Route::get('/dashboard', [DashboardController::class, 'index'])
     ->middleware(['auth', 'verified'])
     ->name('dashboard');
 
-// CRUD menu - HANYA untuk user yang sudah login
-Route::middleware(['auth'])->group(function () {
+// CRUD menu - hanya untuk user dengan role admin
+Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::resource('guru', GuruController::class)->except('show');
     Route::resource('siswa', SiswaController::class)->except('show');
     Route::resource('mapel', MapelController::class)->except('show');


### PR DESCRIPTION
## Summary
- add a simple role middleware and register it
- save user role on registration
- restrict CRUD routes to admin role
- hide admin menu links for non-admin users
- expose role on user model

## Testing
- `php -v` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680ec5edb8832bbee129ad7c5b510c