### PR TITLE
Add sample user seeder

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -22,6 +22,7 @@ class DatabaseSeeder extends Seeder
             AbsensiSeeder::class,
             PengajaranSeeder::class,
             AdminSeeder::class,
+            UserSeeder::class,
         ]);
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+
+class UserSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $users = [
+            [
+                'name' => 'Guru',
+                'email' => 'guru@demo.com',
+                'password' => Hash::make('password'),
+                'role' => 'guru',
+            ],
+            [
+                'name' => 'Siswa',
+                'email' => 'siswa@demo.com',
+                'password' => Hash::make('password'),
+                'role' => 'siswa',
+            ],
+        ];
+
+        foreach ($users as $user) {
+            User::updateOrCreate(
+                ['email' => $user['email']],
+                $user
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- seed example `User` accounts for `guru` and `siswa` roles
- include `UserSeeder` in the main `DatabaseSeeder`

## Testing
- `composer install`
- `php artisan test` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_686813671bf0832baffea283dd5dc2b5