### PR TITLE
Add role based access for guru

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Aplikasi Sistem Informasi Akademik berbasis Laravel.
 - Absensi Harian Siswa
 - Input dan Cetak Rapor
 - Manajemen Siswa & Kelas
+- Hak akses berdasarkan role:
+  - **Admin** dapat mengelola data guru, siswa, mata pelajaran, nilai dan absensi.
+  - **Guru** dapat mengelola nilai dan absensi siswa.
 
 ## Instalasi Lokal
 ```bash

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -56,6 +56,9 @@
                     <a href="{{ route('mapel.index') }}" class="list-group-item list-group-item-action">
                         <i class="bi bi-book me-2"></i>Manajemen Mapel
                     </a>
+                @endif
+
+                @if(in_array(Auth::user()->role, ['admin', 'guru']))
                     <a href="{{ route('nilai.index') }}" class="list-group-item list-group-item-action">
                         <i class="bi bi-card-checklist me-2"></i>Nilai Siswa
                     </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,22 +20,25 @@ Route::get('/dashboard', [DashboardController::class, 'index'])
     ->middleware(['auth', 'verified'])
     ->name('dashboard');
 
-// CRUD menu - hanya untuk user dengan role admin
+// Manajemen data khusus admin
 Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::resource('guru', GuruController::class)->except('show');
     Route::resource('siswa', SiswaController::class)->except('show');
     Route::resource('mapel', MapelController::class)->except('show');
+    Route::get('/siswa-export', [SiswaController::class, 'export'])->name('siswa.export');
+});
+
+// Fitur yang dapat diakses oleh admin dan guru
+Route::middleware(['auth', 'role:admin,guru'])->group(function () {
     Route::resource('nilai', NilaiController::class)->except('show');
     Route::resource('absensi', AbsensiController::class)->except('show');
     Route::get('/absensi/rekap', [AbsensiController::class, 'rekap'])->name('absensi.rekap');
     Route::get('/absensi/rekap/export', [AbsensiController::class, 'exportRekap'])->name('absensi.rekap.export');
-    
     Route::get('/rapor/{siswa}', [RaporController::class, 'cetak'])->name('rapor.cetak');
-    Route::get('/siswa-export', [SiswaController::class, 'export'])->name('siswa.export');
+});
 
-
-
-    // Profile edit
+// Profile dapat diakses oleh semua user yang login
+Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');


### PR DESCRIPTION
## Summary
- extend README with role-based access information
- display menu items for `guru` in app layout
- split routes so `guru` can manage grades and attendance

## Testing
- `php artisan test` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_6868182e7c1c832b81439cfc0ab40238