### PR TITLE
Add student self service pages

### DIFF
--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Siswa;
+use App\Models\Nilai;
+use Illuminate\Support\Facades\Auth;
+use PDF;
+
+class StudentController extends Controller
+{
+    /**
+     * Display logged in student's profile.
+     */
+    public function profil()
+    {
+        $siswa = Siswa::where('nama', Auth::user()->name)->firstOrFail();
+        return view('siswa.show', compact('siswa'));
+    }
+
+    /**
+     * Show logged in student's attendance records.
+     */
+    public function absensi()
+    {
+        $siswa = Siswa::where('nama', Auth::user()->name)->firstOrFail();
+        $absensi = $siswa->absensi()->get();
+        return view('siswa.absensi', compact('siswa', 'absensi'));
+    }
+
+    /**
+     * Show logged in student's grades.
+     */
+    public function nilai()
+    {
+        $siswa = Siswa::where('nama', Auth::user()->name)->firstOrFail();
+        $nilai = Nilai::with('mapel')->where('siswa_id', $siswa->id)->get();
+        return view('siswa.nilai', compact('siswa', 'nilai'));
+    }
+
+    /**
+     * Download logged in student's report.
+     */
+    public function rapor()
+    {
+        $siswa = Siswa::where('nama', Auth::user()->name)->firstOrFail();
+        $nilai = Nilai::with('mapel')->where('siswa_id', $siswa->id)->get();
+
+        $pdf = PDF::loadView('rapor.pdf', [
+            'siswa' => $siswa,
+            'nilai' => $nilai,
+        ]);
+
+        return $pdf->download('rapor-'.$siswa->nama.'.pdf');
+    }
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -66,6 +66,18 @@
                         <i class="bi bi-person-check me-2"></i>Absensi Siswa
                     </a>
                 @endif
+
+                @if(Auth::user()->role === 'siswa')
+                    <a href="{{ route('student.profile') }}" class="list-group-item list-group-item-action">
+                        <i class="bi bi-person me-2"></i>Data Diri
+                    </a>
+                    <a href="{{ route('student.absensi') }}" class="list-group-item list-group-item-action">
+                        <i class="bi bi-person-check me-2"></i>Absensi Saya
+                    </a>
+                    <a href="{{ route('student.nilai') }}" class="list-group-item list-group-item-action">
+                        <i class="bi bi-card-checklist me-2"></i>Nilai Saya
+                    </a>
+                @endif
             </div>
         </div>
     </div>

--- a/resources/views/siswa/absensi.blade.php
+++ b/resources/views/siswa/absensi.blade.php
@@ -1,0 +1,23 @@
+@extends('layouts.app')
+
+@section('title', 'Absensi Saya')
+
+@section('content')
+<h1 class="mb-3">Absensi Saya</h1>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Tanggal</th>
+            <th>Status</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach($absensi as $a)
+        <tr>
+            <td>{{ $a->tanggal }}</td>
+            <td>{{ $a->status }}</td>
+        </tr>
+        @endforeach
+    </tbody>
+</table>
+@endsection

--- a/resources/views/siswa/nilai.blade.php
+++ b/resources/views/siswa/nilai.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.app')
+
+@section('title', 'Nilai Saya')
+
+@section('content')
+<h1 class="mb-3">Nilai Saya</h1>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Mata Pelajaran</th>
+            <th>Nilai</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach($nilai as $n)
+        <tr>
+            <td>{{ $n->mapel->nama }}</td>
+            <td>{{ $n->nilai }}</td>
+        </tr>
+        @endforeach
+    </tbody>
+</table>
+<a href="{{ route('student.rapor') }}" class="btn btn-primary mt-3">Download Rapor</a>
+@endsection

--- a/resources/views/siswa/show.blade.php
+++ b/resources/views/siswa/show.blade.php
@@ -1,0 +1,12 @@
+@extends('layouts.app')
+
+@section('title', 'Data Diri')
+
+@section('content')
+<h1 class="mb-3">Data Diri</h1>
+<table class="table table-bordered w-50">
+    <tr><th>Nama</th><td>{{ $siswa->nama }}</td></tr>
+    <tr><th>Kelas</th><td>{{ $siswa->kelas }}</td></tr>
+    <tr><th>Tanggal Lahir</th><td>{{ $siswa->tanggal_lahir }}</td></tr>
+</table>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\MapelController;
 use App\Http\Controllers\NilaiController;
 use App\Http\Controllers\AbsensiController;
 use App\Http\Controllers\RaporController;
+use App\Http\Controllers\StudentController;
 
 // Landing page
 Route::get('/', function () {
@@ -42,6 +43,14 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+});
+
+// Routes khusus siswa untuk melihat data sendiri
+Route::middleware(['auth', 'role:siswa'])->group(function () {
+    Route::get('/saya', [StudentController::class, 'profil'])->name('student.profile');
+    Route::get('/saya/absensi', [StudentController::class, 'absensi'])->name('student.absensi');
+    Route::get('/saya/nilai', [StudentController::class, 'nilai'])->name('student.nilai');
+    Route::get('/saya/rapor', [StudentController::class, 'rapor'])->name('student.rapor');
 });
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- add StudentController with actions for profile, attendance and grades
- add routes for student self-service
- show menu links for students in layout
- add views to display student data

## Testing
- `composer install` *(fails: composer not found)*
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681b4ec570832b8b99f9a574b7b53b