### PR TITLE
Ensure demo teacher has associated data

### DIFF
--- a/database/seeders/GuruSeeder.php
+++ b/database/seeders/GuruSeeder.php
@@ -14,8 +14,9 @@ class GuruSeeder extends Seeder
         $data = [];
         for ($i = 1; $i <= 20; $i++) {
             $data[] = [
+                // Gunakan nama "Guru" untuk id pertama agar sesuai dengan user default
                 'nip' => str_pad($i, 18, '0', STR_PAD_LEFT),
-                'nama' => $faker->unique()->name,
+                'nama' => $i === 1 ? 'Guru' : $faker->unique()->name,
             ];
         }
         DB::table('guru')->insert($data);


### PR DESCRIPTION
## Summary
- make the first seeded teacher named `Guru` so the default `guru` user matches an entry in the `guru` table

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686821b66b54832bb9f2babba81f4c95