### PR TITLE
Adjust user creation flow based on role

### DIFF
--- a/app/Models/Guru.php
+++ b/app/Models/Guru.php
@@ -10,7 +10,7 @@ class Guru extends Model
     use HasFactory;
 
     protected $table = 'guru';
-    protected $fillable = ['nip', 'nama', 'user_id'];
+    protected $fillable = ['nip', 'nama', 'tanggal_lahir', 'user_id'];
 
     public function user()
     {

--- a/database/migrations/2025_07_04_000003_add_tanggal_lahir_to_guru_table.php
+++ b/database/migrations/2025_07_04_000003_add_tanggal_lahir_to_guru_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('guru', function (Blueprint $table) {
+            $table->date('tanggal_lahir')->nullable()->after('nama');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('guru', function (Blueprint $table) {
+            $table->dropColumn('tanggal_lahir');
+        });
+    }
+};

--- a/database/seeders/GuruSeeder.php
+++ b/database/seeders/GuruSeeder.php
@@ -18,6 +18,7 @@ class GuruSeeder extends Seeder
             $data[] = [
                 'nip' => str_pad($i, 18, '0', STR_PAD_LEFT),
                 'nama' => $i === 1 ? 'Guru' : $faker->unique()->name,
+                'tanggal_lahir' => $faker->dateTimeBetween('1980-01-01', '1995-12-31')->format('Y-m-d'),
                 'user_id' => $i === 1 && $guruUser ? $guruUser->id : null,
             ];
         }

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -7,48 +7,105 @@
 <form action="{{ route('users.store') }}" method="POST">
     @csrf
     <div class="mb-3">
-        <label>Nama</label>
-        <input type="text" name="name" class="form-control" required>
-    </div>
-    <div class="mb-3">
-        <label>Email</label>
-        <input type="email" name="email" class="form-control" required>
-    </div>
-    <div class="mb-3">
-        <label>Password</label>
-        <input type="password" name="password" class="form-control" required>
-    </div>
-    <div class="mb-3">
-        <label>Konfirmasi Password</label>
-        <input type="password" name="password_confirmation" class="form-control" required>
-    </div>
-    <div class="mb-3">
         <label>Role</label>
-        <select name="role" class="form-control" required>
+        <select name="role" class="form-control" id="role-select" required>
             <option value="admin">admin</option>
             <option value="guru">guru</option>
             <option value="siswa">siswa</option>
         </select>
     </div>
-    <div class="mb-3">
-        <label>Kaitkan Guru (opsional)</label>
-        <select name="guru_id" class="form-control">
+    <div class="mb-3" id="field-name">
+        <label>Nama</label>
+        <input type="text" name="name" class="form-control">
+    </div>
+    <div class="mb-3" id="field-email">
+        <label>Email</label>
+        <input type="email" name="email" class="form-control">
+    </div>
+    <div class="mb-3" id="field-password">
+        <label>Password</label>
+        <input type="password" name="password" class="form-control">
+    </div>
+    <div class="mb-3" id="field-password-confirm">
+        <label>Konfirmasi Password</label>
+        <input type="password" name="password_confirmation" class="form-control">
+    </div>
+    <div class="mb-3" id="field-guru" style="display:none;">
+        <label>Pilih Guru</label>
+        <select name="guru_id" class="form-control" id="guru-select">
             <option value="">-</option>
             @foreach ($guru as $g)
-                <option value="{{ $g->id }}">{{ $g->nama }}</option>
+                <option value="{{ $g->id }}" data-nip="{{ $g->nip }}" data-tanggallahir="{{ $g->tanggal_lahir }}">{{ $g->nip }} - {{ $g->nama }}</option>
             @endforeach
         </select>
     </div>
-    <div class="mb-3">
-        <label>Kaitkan Siswa (opsional)</label>
-        <select name="siswa_id" class="form-control">
+    <div class="mb-3" id="field-siswa" style="display:none;">
+        <label>Pilih Siswa</label>
+        <select name="siswa_id" class="form-control" id="siswa-select">
             <option value="">-</option>
             @foreach ($siswa as $s)
-                <option value="{{ $s->id }}">{{ $s->nama }}</option>
+                <option value="{{ $s->id }}" data-nisn="{{ $s->nisn }}" data-tanggallahir="{{ $s->tanggal_lahir }}">{{ $s->nisn }} - {{ $s->nama }}</option>
             @endforeach
         </select>
     </div>
     <button class="btn btn-success">Simpan</button>
     <a href="{{ route('users.index') }}" class="btn btn-secondary">Batal</a>
 </form>
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+    const roleSelect = document.getElementById('role-select');
+    const guruSelect = document.getElementById('guru-select');
+    const siswaSelect = document.getElementById('siswa-select');
+    const fieldGuru = document.getElementById('field-guru');
+    const fieldSiswa = document.getElementById('field-siswa');
+    const nameInput = document.querySelector('input[name="name"]');
+    const emailInput = document.querySelector('input[name="email"]');
+    const passInput = document.querySelector('input[name="password"]');
+    const passConfirm = document.querySelector('input[name="password_confirmation"]');
+
+    function setFromOption(opt, type) {
+        const id = type === 'guru' ? opt.dataset.nip : opt.dataset.nisn;
+        const tgl = opt.dataset.tanggallahir || '';
+        if (id) {
+            nameInput.value = id + ' - ' + opt.textContent.trim().split(' - ').slice(1).join(' - ');
+            emailInput.value = id + '@muhammadiyah.co.id';
+            if (tgl) {
+                const parts = tgl.split('-');
+                passInput.value = parts[0].slice(2) + parts[1] + parts[2];
+                passConfirm.value = passInput.value;
+            }
+        }
+    }
+
+    function updateVisibility() {
+        const role = roleSelect.value;
+        if (role === 'guru') {
+            fieldGuru.style.display = '';
+            fieldSiswa.style.display = 'none';
+            if (guruSelect.selectedIndex > 0) {
+                setFromOption(guruSelect.options[guruSelect.selectedIndex], 'guru');
+            }
+        } else if (role === 'siswa') {
+            fieldGuru.style.display = 'none';
+            fieldSiswa.style.display = '';
+            if (siswaSelect.selectedIndex > 0) {
+                setFromOption(siswaSelect.options[siswaSelect.selectedIndex], 'siswa');
+            }
+        } else {
+            fieldGuru.style.display = 'none';
+            fieldSiswa.style.display = 'none';
+            nameInput.value = '';
+            emailInput.value = '';
+            passInput.value = '';
+            passConfirm.value = '';
+        }
+    }
+
+    roleSelect.addEventListener('change', updateVisibility);
+    guruSelect.addEventListener('change', function() { setFromOption(this.options[this.selectedIndex], 'guru'); });
+    siswaSelect.addEventListener('change', function() { setFromOption(this.options[this.selectedIndex], 'siswa'); });
+
+    updateVisibility();
+});
+</script>
 @endsection


### PR DESCRIPTION
## Summary
- migrate: add tanggal_lahir to guru table
- seeders: fill guru birth dates
- models: allow tanggal_lahir on Guru
- controller: auto-fill name, email and password when creating user as guru or siswa
- view: update user creation form with JS to auto-populate fields

## Testing
- `composer install --no-interaction`
- `php artisan test` *(fails: could not find driver)*

------
https://chatgpt.com/codex/tasks/task_e_686951014250832b9e0278774e50c4e2