### PR TITLE
Add unique constraint to pengajaran

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Aplikasi Sistem Informasi Akademik berbasis Laravel.
 - Hak akses berdasarkan role:
   - **Admin** dapat mengelola data guru, siswa, mata pelajaran, nilai dan absensi.
   - **Guru** dapat mengelola nilai dan absensi siswa.
+- Sistem memastikan kombinasi guru, mata pelajaran dan kelas pada menu
+  **Pengajaran** tidak bisa diduplikasi.
 
 ## Instalasi Lokal
 ```bash

--- a/app/Http/Controllers/PengajaranController.php
+++ b/app/Http/Controllers/PengajaranController.php
@@ -7,6 +7,7 @@ use App\Models\Guru;
 use App\Models\MataPelajaran;
 use App\Models\Kelas;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class PengajaranController extends Controller
 {
@@ -42,11 +43,20 @@ class PengajaranController extends Controller
 
     public function store(Request $request)
     {
-        Pengajaran::create($request->validate([
-            'guru_id' => 'required|exists:guru,id',
-            'mapel_id' => 'required|exists:mata_pelajaran,id',
-            'kelas' => 'required|exists:kelas,nama'
-        ]));
+        $validated = $request->validate([
+            'guru_id' => [
+                'required',
+                'exists:guru,id',
+                Rule::unique('pengajaran')->where('mapel_id', $request->input('mapel_id'))->where('kelas', $request->input('kelas')),
+            ],
+            'mapel_id' => ['required', 'exists:mata_pelajaran,id'],
+            'kelas' => ['required', 'exists:kelas,nama'],
+        ]);
+
+        $validated['guru_id'] = (int) $validated['guru_id'];
+        $validated['mapel_id'] = (int) $validated['mapel_id'];
+
+        Pengajaran::create($validated);
 
         return redirect()->route('pengajaran.index')->with('success', 'Data pengajaran berhasil ditambahkan');
     }
@@ -61,11 +71,20 @@ class PengajaranController extends Controller
 
     public function update(Request $request, Pengajaran $pengajaran)
     {
-        $pengajaran->update($request->validate([
-            'guru_id' => 'required|exists:guru,id',
-            'mapel_id' => 'required|exists:mata_pelajaran,id',
-            'kelas' => 'required|exists:kelas,nama'
-        ]));
+        $validated = $request->validate([
+            'guru_id' => [
+                'required',
+                'exists:guru,id',
+                Rule::unique('pengajaran')->where('mapel_id', $request->input('mapel_id'))->where('kelas', $request->input('kelas'))->ignore($pengajaran->id),
+            ],
+            'mapel_id' => ['required', 'exists:mata_pelajaran,id'],
+            'kelas' => ['required', 'exists:kelas,nama'],
+        ]);
+
+        $validated['guru_id'] = (int) $validated['guru_id'];
+        $validated['mapel_id'] = (int) $validated['mapel_id'];
+
+        $pengajaran->update($validated);
 
         return redirect()->route('pengajaran.index')->with('success', 'Data pengajaran berhasil diupdate');
     }

--- a/database/migrations/2025_07_04_000004_add_unique_pengajaran.php
+++ b/database/migrations/2025_07_04_000004_add_unique_pengajaran.php
@@ -1,0 +1,19 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void {
+        Schema::table('pengajaran', function (Blueprint $table) {
+            $table->unique(['guru_id', 'mapel_id', 'kelas'], 'pengajaran_unique');
+        });
+    }
+
+    public function down(): void {
+        Schema::table('pengajaran', function (Blueprint $table) {
+            $table->dropUnique('pengajaran_unique');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- prevent duplicate teaching assignments by enforcing unique combination of guru, mapel and kelas
- add Rule::unique validation in `PengajaranController`
- document the restriction in README

## Testing
- `php artisan test` *(fails: vendor folder missing)*
- `composer install` *(fails: composer not found due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68697f85955c832bb4da751748e805d1