### PR TITLE
Update Pengajaran form to allow typed teacher name

### DIFF
--- a/app/Http/Controllers/PengajaranController.php
+++ b/app/Http/Controllers/PengajaranController.php
@@ -44,19 +44,25 @@ class PengajaranController extends Controller
     public function store(Request $request)
     {
         $validated = $request->validate([
-            'guru_id' => [
-                'required',
-                'exists:guru,id',
-                Rule::unique('pengajaran')->where('mapel_id', $request->input('mapel_id'))->where('kelas', $request->input('kelas')),
-            ],
+            'guru_nama' => ['required', 'exists:guru,nama'],
             'mapel_id' => ['required', 'exists:mata_pelajaran,id'],
             'kelas' => ['required', 'exists:kelas,nama'],
         ]);
 
-        $validated['guru_id'] = (int) $validated['guru_id'];
-        $validated['mapel_id'] = (int) $validated['mapel_id'];
+        $guru = Guru::where('nama', $validated['guru_nama'])->first();
+        $exists = Pengajaran::where('guru_id', $guru->id)
+            ->where('mapel_id', $validated['mapel_id'])
+            ->where('kelas', $validated['kelas'])
+            ->exists();
+        if ($exists) {
+            return back()->withInput()->with('error', 'Data pengajaran sudah ada');
+        }
 
-        Pengajaran::create($validated);
+        Pengajaran::create([
+            'guru_id' => $guru->id,
+            'mapel_id' => (int) $validated['mapel_id'],
+            'kelas' => $validated['kelas'],
+        ]);
 
         return redirect()->route('pengajaran.index')->with('success', 'Data pengajaran berhasil ditambahkan');
     }
@@ -72,19 +78,26 @@ class PengajaranController extends Controller
     public function update(Request $request, Pengajaran $pengajaran)
     {
         $validated = $request->validate([
-            'guru_id' => [
-                'required',
-                'exists:guru,id',
-                Rule::unique('pengajaran')->where('mapel_id', $request->input('mapel_id'))->where('kelas', $request->input('kelas'))->ignore($pengajaran->id),
-            ],
+            'guru_nama' => ['required', 'exists:guru,nama'],
             'mapel_id' => ['required', 'exists:mata_pelajaran,id'],
             'kelas' => ['required', 'exists:kelas,nama'],
         ]);
 
-        $validated['guru_id'] = (int) $validated['guru_id'];
-        $validated['mapel_id'] = (int) $validated['mapel_id'];
+        $guru = Guru::where('nama', $validated['guru_nama'])->first();
+        $exists = Pengajaran::where('guru_id', $guru->id)
+            ->where('mapel_id', $validated['mapel_id'])
+            ->where('kelas', $validated['kelas'])
+            ->where('id', '!=', $pengajaran->id)
+            ->exists();
+        if ($exists) {
+            return back()->withInput()->with('error', 'Data pengajaran sudah ada');
+        }
 
-        $pengajaran->update($validated);
+        $pengajaran->update([
+            'guru_id' => $guru->id,
+            'mapel_id' => (int) $validated['mapel_id'],
+            'kelas' => $validated['kelas'],
+        ]);
 
         return redirect()->route('pengajaran.index')->with('success', 'Data pengajaran berhasil diupdate');
     }

--- a/resources/views/pengajaran/create.blade.php
+++ b/resources/views/pengajaran/create.blade.php
@@ -4,15 +4,19 @@
 
 @section('content')
 <h1>Tambah Pengajaran</h1>
+@if(session('error'))
+    <div class="alert alert-danger">{{ session('error') }}</div>
+@endif
 <form action="{{ route('pengajaran.store') }}" method="POST">
     @csrf
     <div class="mb-3">
         <label>Guru</label>
-        <select name="guru_id" class="form-control" required>
+        <input list="guru_list" name="guru_nama" value="{{ old('guru_nama') }}" class="form-control" required>
+        <datalist id="guru_list">
             @foreach($guru as $g)
-                <option value="{{ $g->id }}">{{ $g->nama }}</option>
+                <option value="{{ $g->nama }}"></option>
             @endforeach
-        </select>
+        </datalist>
     </div>
     <div class="mb-3">
         <label>Mata Pelajaran</label>

--- a/resources/views/pengajaran/edit.blade.php
+++ b/resources/views/pengajaran/edit.blade.php
@@ -4,15 +4,19 @@
 
 @section('content')
 <h1>Edit Pengajaran</h1>
+@if(session('error'))
+    <div class="alert alert-danger">{{ session('error') }}</div>
+@endif
 <form action="{{ route('pengajaran.update', $pengajaran->id) }}" method="POST">
     @csrf @method('PUT')
     <div class="mb-3">
         <label>Guru</label>
-        <select name="guru_id" class="form-control" required>
+        <input list="guru_list" name="guru_nama" value="{{ old('guru_nama', $pengajaran->guru->nama) }}" class="form-control" required>
+        <datalist id="guru_list">
             @foreach($guru as $g)
-                <option value="{{ $g->id }}" @selected($pengajaran->guru_id == $g->id)>{{ $g->nama }}</option>
+                <option value="{{ $g->nama }}"></option>
             @endforeach
-        </select>
+        </datalist>
     </div>
     <div class="mb-3">
         <label>Mata Pelajaran</label>


### PR DESCRIPTION
## Summary
- allow typing teacher name instead of dropdown on create & edit
- show duplicate entry error
- adjust controller logic to map typed name to ID

## Testing
- `./vendor/bin/phpunit` *(fails: Missing APP_KEY and other setup)*

------
https://chatgpt.com/codex/tasks/task_e_686980f7e534832ba0358e17a0eff2dd