### PR TITLE
Ensure Jadwal syncs Pengajaran

### DIFF
--- a/app/Http/Controllers/JadwalController.php
+++ b/app/Http/Controllers/JadwalController.php
@@ -6,10 +6,23 @@ use App\Models\Jadwal;
 use App\Models\Kelas;
 use App\Models\MataPelajaran;
 use App\Models\Guru;
+use App\Models\Pengajaran;
 use Illuminate\Http\Request;
 
 class JadwalController extends Controller
 {
+    private function syncPengajaran(array $data): void
+    {
+        $kelasNama = Kelas::find($data['kelas_id'])->nama ?? null;
+        if (!$kelasNama) {
+            return;
+        }
+        Pengajaran::firstOrCreate([
+            'guru_id' => $data['guru_id'],
+            'mapel_id' => $data['mapel_id'],
+            'kelas' => $kelasNama,
+        ]);
+    }
     public function index()
     {
         $jadwal = Jadwal::with(['kelas', 'mapel', 'guru'])->get()->groupBy('hari');
@@ -35,6 +48,7 @@ class JadwalController extends Controller
             'jam_selesai' => 'required',
         ]);
         Jadwal::create($data);
+        $this->syncPengajaran($data);
 
         return redirect()->route('jadwal.index')->with('success', 'Jadwal berhasil ditambahkan');
     }
@@ -58,6 +72,7 @@ class JadwalController extends Controller
             'jam_selesai' => 'required',
         ]);
         $jadwal->update($data);
+        $this->syncPengajaran($data);
 
         return redirect()->route('jadwal.index')->with('success', 'Jadwal berhasil diupdate');
     }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,6 +23,7 @@
         <env name="CACHE_DRIVER" value="array"/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
+        <env name="APP_KEY" value="base64:rpeiLkF1WNbPzPeWon0SLnrBl5NxSEfZsgepcFRhdJ4="/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/tests/Feature/JadwalPengajaranSyncTest.php
+++ b/tests/Feature/JadwalPengajaranSyncTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\Pengajaran;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class JadwalPengajaranSyncTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_store_jadwal_creates_pengajaran_record(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $guru = Guru::create([
+            'nip' => '123',
+            'nama' => 'Guru Test',
+            'tanggal_lahir' => '1980-01-01',
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'Matematika']);
+        $kelas = Kelas::create(['nama' => '10A']);
+
+        $response = $this->actingAs($user)->post('/jadwal', [
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+        $response->assertRedirect('/jadwal');
+
+        $this->assertDatabaseHas('pengajaran', [
+            'guru_id' => $guru->id,
+            'mapel_id' => $mapel->id,
+            'kelas' => $kelas->nama,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- sync Jadwal data with Pengajaran when schedules are saved
- provide APP_KEY for tests
- add feature test for the sync logic

## Testing
- `./vendor/bin/phpunit --stop-on-failure tests/Feature/JadwalPengajaranSyncTest.php`
- `./vendor/bin/phpunit` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686989e2952c832b839f9d0ca99da720