### PR TITLE
Add schedule conflict validation

### DIFF
--- a/app/Http/Controllers/JadwalController.php
+++ b/app/Http/Controllers/JadwalController.php
@@ -47,6 +47,21 @@ class JadwalController extends Controller
             'jam_mulai' => 'required',
             'jam_selesai' => 'required',
         ]);
+        $exists = Jadwal::where('guru_id', $data['guru_id'])
+            ->where('hari', $data['hari'])
+            ->where(function ($q) use ($data) {
+                $q->whereBetween('jam_mulai', [$data['jam_mulai'], $data['jam_selesai']])
+                    ->orWhereBetween('jam_selesai', [$data['jam_mulai'], $data['jam_selesai']])
+                    ->orWhere(function ($q2) use ($data) {
+                        $q2->where('jam_mulai', '<=', $data['jam_mulai'])
+                            ->where('jam_selesai', '>=', $data['jam_selesai']);
+                    });
+            })
+            ->exists();
+
+        if ($exists) {
+            return back()->withInput()->with('error', 'Guru sudah dijadwalkan pada jam tersebut');
+        }
         Jadwal::create($data);
         $this->syncPengajaran($data);
 
@@ -71,6 +86,22 @@ class JadwalController extends Controller
             'jam_mulai' => 'required',
             'jam_selesai' => 'required',
         ]);
+        $exists = Jadwal::where('guru_id', $data['guru_id'])
+            ->where('hari', $data['hari'])
+            ->where('id', '!=', $jadwal->id)
+            ->where(function ($q) use ($data) {
+                $q->whereBetween('jam_mulai', [$data['jam_mulai'], $data['jam_selesai']])
+                    ->orWhereBetween('jam_selesai', [$data['jam_mulai'], $data['jam_selesai']])
+                    ->orWhere(function ($q2) use ($data) {
+                        $q2->where('jam_mulai', '<=', $data['jam_mulai'])
+                            ->where('jam_selesai', '>=', $data['jam_selesai']);
+                    });
+            })
+            ->exists();
+
+        if ($exists) {
+            return back()->withInput()->with('error', 'Guru sudah dijadwalkan pada jam tersebut');
+        }
         $jadwal->update($data);
         $this->syncPengajaran($data);
 

--- a/public/build/manifest.json
+++ b/public/build/manifest.json
@@ -1,0 +1,4 @@
+{
+  "resources/css/app.css": {"file": "app.css", "src": "resources/css/app.css"},
+  "resources/js/app.js": {"file": "app.js", "src": "resources/js/app.js"}
+}

--- a/resources/views/jadwal/create.blade.php
+++ b/resources/views/jadwal/create.blade.php
@@ -4,6 +4,9 @@
 
 @section('content')
 <h1>Tambah Jadwal</h1>
+@if(session('error'))
+    <div class="alert alert-danger">{{ session('error') }}</div>
+@endif
 <form action="{{ route('jadwal.store') }}" method="POST">
     @csrf
     <div class="mb-3">

--- a/resources/views/jadwal/edit.blade.php
+++ b/resources/views/jadwal/edit.blade.php
@@ -4,6 +4,9 @@
 
 @section('content')
 <h1>Edit Jadwal</h1>
+@if(session('error'))
+    <div class="alert alert-danger">{{ session('error') }}</div>
+@endif
 <form action="{{ route('jadwal.update', $jadwal->id) }}" method="POST">
     @csrf @method('PUT')
     <div class="mb-3">

--- a/tests/Feature/JadwalConflictTest.php
+++ b/tests/Feature/JadwalConflictTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\Jadwal;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class JadwalConflictTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_teacher_cannot_have_overlapping_schedule(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $guru = Guru::create([
+            'nip' => '111',
+            'nama' => 'Guru A',
+            'tanggal_lahir' => '1980-01-01',
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'Matematika']);
+        $kelasA = Kelas::create(['nama' => 'A']);
+        $kelasB = Kelas::create(['nama' => 'B']);
+
+        $this->actingAs($user)->post('/jadwal', [
+            'kelas_id' => $kelasA->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ])->assertRedirect('/jadwal');
+
+        $response = $this->actingAs($user)
+            ->from('/jadwal/create')
+            ->post('/jadwal', [
+                'kelas_id' => $kelasB->id,
+                'mapel_id' => $mapel->id,
+                'guru_id' => $guru->id,
+                'hari' => 'Senin',
+                'jam_mulai' => '07:30',
+                'jam_selesai' => '08:30',
+            ]);
+
+        $response->assertRedirect('/jadwal/create');
+        $response->assertSessionHas('error', 'Guru sudah dijadwalkan pada jam tersebut');
+
+        $this->assertEquals(1, Jadwal::count());
+    }
+}
+


### PR DESCRIPTION
## Summary
- prevent overlapping schedules in `JadwalController`
- show error flash on jadwal forms
- test teacher schedule conflict
- include dummy vite manifest for tests

## Testing
- `composer install`
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68699355032c832b8236e0884178b52f