### PR TITLE
Add class filter to schedule page

### DIFF
--- a/app/Http/Controllers/JadwalController.php
+++ b/app/Http/Controllers/JadwalController.php
@@ -23,10 +23,23 @@ class JadwalController extends Controller
             'kelas' => $kelasNama,
         ]);
     }
-    public function index()
+    public function index(Request $request)
     {
-        $jadwal = Jadwal::with(['kelas', 'mapel', 'guru'])->get()->groupBy('hari');
-        return view('jadwal.index', compact('jadwal'));
+        $kelasId = $request->query('kelas');
+        $kelasList = Kelas::pluck('nama', 'id');
+
+        $query = Jadwal::with(['kelas', 'mapel', 'guru']);
+        if ($kelasId) {
+            $query->where('kelas_id', $kelasId);
+        }
+
+        $jadwal = $query->get()->groupBy('hari');
+
+        return view('jadwal.index', [
+            'jadwal' => $jadwal,
+            'kelasList' => $kelasList,
+            'selectedKelas' => $kelasId,
+        ]);
     }
 
     public function create()

--- a/resources/views/jadwal/index.blade.php
+++ b/resources/views/jadwal/index.blade.php
@@ -7,6 +7,15 @@
     <h1>Jadwal Pelajaran</h1>
     <a href="{{ route('jadwal.create') }}" class="btn btn-primary">+ Tambah Jadwal</a>
 </div>
+<form method="GET" action="{{ route('jadwal.index') }}" class="mb-3 d-flex">
+    <select name="kelas" class="form-select me-2" onchange="this.form.submit()">
+        <option value="">Semua Kelas</option>
+        @foreach($kelasList as $id => $nama)
+            <option value="{{ $id }}" {{ $id == $selectedKelas ? 'selected' : '' }}>{{ $nama }}</option>
+        @endforeach
+    </select>
+    <noscript><button class="btn btn-primary">Lihat</button></noscript>
+</form>
 @if(session('success'))
     <div class="alert alert-success">{{ session('success') }}</div>
 @endif


### PR DESCRIPTION
## Summary
- allow filtering schedule by class
- show class dropdown on schedule index page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68699d1fd888832bb221b9fa5cc0d7d7