### PR TITLE
Add unique constraint on pengajaran mapel+kelas

### DIFF
--- a/app/Http/Controllers/PengajaranController.php
+++ b/app/Http/Controllers/PengajaranController.php
@@ -50,8 +50,7 @@ class PengajaranController extends Controller
         ]);
 
         $guru = Guru::where('nama', $validated['guru_nama'])->first();
-        $exists = Pengajaran::where('guru_id', $guru->id)
-            ->where('mapel_id', $validated['mapel_id'])
+        $exists = Pengajaran::where('mapel_id', $validated['mapel_id'])
             ->where('kelas', $validated['kelas'])
             ->exists();
         if ($exists) {
@@ -84,8 +83,7 @@ class PengajaranController extends Controller
         ]);
 
         $guru = Guru::where('nama', $validated['guru_nama'])->first();
-        $exists = Pengajaran::where('guru_id', $guru->id)
-            ->where('mapel_id', $validated['mapel_id'])
+        $exists = Pengajaran::where('mapel_id', $validated['mapel_id'])
             ->where('kelas', $validated['kelas'])
             ->where('id', '!=', $pengajaran->id)
             ->exists();

--- a/database/migrations/2025_07_04_000005_add_unique_mapel_kelas_to_pengajaran_table.php
+++ b/database/migrations/2025_07_04_000005_add_unique_mapel_kelas_to_pengajaran_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('pengajaran', function (Blueprint $table) {
+            $table->unique(['mapel_id', 'kelas'], 'pengajaran_mapel_kelas_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('pengajaran', function (Blueprint $table) {
+            $table->dropUnique('pengajaran_mapel_kelas_unique');
+        });
+    }
+};

--- a/database/seeders/PengajaranSeeder.php
+++ b/database/seeders/PengajaranSeeder.php
@@ -10,12 +10,17 @@ class PengajaranSeeder extends Seeder
     public function run(): void
     {
         $data = [];
-        for ($i = 1; $i <= 30; $i++) {
-            $data[] = [
-                'guru_id' => ($i % 20) + 1,
-                'mapel_id' => ($i % 10) + 1,
-                'kelas' => '10' . chr(64 + ($i % 3) + 1),
-            ];
+        $kelasList = ['10A', '10B', '10C'];
+        $index = 0;
+        for ($mapel = 1; $mapel <= 10; $mapel++) {
+            foreach ($kelasList as $kelas) {
+                $data[] = [
+                    'guru_id' => ($index % 20) + 1,
+                    'mapel_id' => $mapel,
+                    'kelas' => $kelas,
+                ];
+                $index++;
+            }
         }
         DB::table('pengajaran')->insert($data);
     }

--- a/tests/Feature/PengajaranUniqueTest.php
+++ b/tests/Feature/PengajaranUniqueTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\Pengajaran;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PengajaranUniqueTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cannot_assign_two_teachers_to_same_subject_and_class(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $guruA = Guru::create([
+            'nip' => '1001',
+            'nama' => 'Guru A',
+            'tanggal_lahir' => '1980-01-01',
+        ]);
+        $guruB = Guru::create([
+            'nip' => '1002',
+            'nama' => 'Guru B',
+            'tanggal_lahir' => '1985-01-01',
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'Matematika']);
+        $kelas = Kelas::create(['nama' => '10A']);
+
+        $this->actingAs($user)->post('/pengajaran', [
+            'guru_nama' => $guruA->nama,
+            'mapel_id' => $mapel->id,
+            'kelas' => $kelas->nama,
+        ])->assertRedirect('/pengajaran');
+
+        $response = $this->actingAs($user)
+            ->from('/pengajaran/create')
+            ->post('/pengajaran', [
+                'guru_nama' => $guruB->nama,
+                'mapel_id' => $mapel->id,
+                'kelas' => $kelas->nama,
+            ]);
+
+        $response->assertRedirect('/pengajaran/create');
+        $response->assertSessionHas('error');
+        $this->assertEquals(1, Pengajaran::count());
+    }
+}


### PR DESCRIPTION
## Summary
- enforce uniqueness on pengajaran `mapel_id` + `kelas`
- validate uniqueness in controller
- seed pengajaran without violating the new index
- test duplicate subject+class assignments

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686a0c3b8abc832b8ba25a0c43925938