### PR TITLE
Fix pengajaran sync in JadwalController

### DIFF
--- a/app/Http/Controllers/JadwalController.php
+++ b/app/Http/Controllers/JadwalController.php
@@ -17,11 +17,15 @@ class JadwalController extends Controller
         if (!$kelasNama) {
             return;
         }
-        Pengajaran::firstOrCreate([
-            'guru_id' => $data['guru_id'],
-            'mapel_id' => $data['mapel_id'],
-            'kelas' => $kelasNama,
-        ]);
+        Pengajaran::updateOrCreate(
+            [
+                'mapel_id' => $data['mapel_id'],
+                'kelas' => $kelasNama,
+            ],
+            [
+                'guru_id' => $data['guru_id'],
+            ]
+        );
     }
     public function index(Request $request)
     {

--- a/tests/Feature/JadwalPengajaranSyncTest.php
+++ b/tests/Feature/JadwalPengajaranSyncTest.php
@@ -41,4 +41,46 @@ class JadwalPengajaranSyncTest extends TestCase
             'kelas' => $kelas->nama,
         ]);
     }
+
+    public function test_store_jadwal_updates_pengajaran_if_subject_and_class_exist(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $guruA = Guru::create([
+            'nip' => '111',
+            'nama' => 'Guru A',
+            'tanggal_lahir' => '1980-01-01',
+        ]);
+        $guruB = Guru::create([
+            'nip' => '222',
+            'nama' => 'Guru B',
+            'tanggal_lahir' => '1985-01-01',
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        $kelas = Kelas::create(['nama' => '10A']);
+
+        $this->actingAs($user)->post('/jadwal', [
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guruA->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ])->assertRedirect('/jadwal');
+
+        $this->actingAs($user)->post('/jadwal', [
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guruB->id,
+            'hari' => 'Selasa',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ])->assertRedirect('/jadwal');
+
+        $this->assertEquals(1, Pengajaran::count());
+        $this->assertDatabaseHas('pengajaran', [
+            'guru_id' => $guruB->id,
+            'mapel_id' => $mapel->id,
+            'kelas' => $kelas->nama,
+        ]);
+    }
 }


### PR DESCRIPTION
## Summary
- fix duplicate entry issue by using `updateOrCreate` when syncing `Pengajaran`
- add test to ensure existing record is updated instead of duplicated

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_686a11c75968832baca32af35d3da1f4