### PR TITLE
Display validation errors for forms

### DIFF
--- a/resources/views/absensi/create.blade.php
+++ b/resources/views/absensi/create.blade.php
@@ -4,6 +4,15 @@
 
 @section('content')
 <h1>Tambah Absensi</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('absensi.store') }}" method="POST">
     @csrf
     <div class="mb-3">
@@ -14,10 +23,12 @@
                 <option value="{{ $s->id }}">{{ $s->nama }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('siswa_id')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Tanggal</label>
         <input type="date" name="tanggal" class="form-control" required>
+        <x-input-error :messages="$errors->get('tanggal')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Status</label>
@@ -28,6 +39,7 @@
             <option value="Sakit">Sakit</option>
             <option value="Alpha">Alpha</option>
         </select>
+        <x-input-error :messages="$errors->get('status')" class="mt-1" />
     </div>
     <button class="btn btn-success">Simpan</button>
     <a href="{{ route('absensi.index') }}" class="btn btn-secondary">Batal</a>

--- a/resources/views/absensi/edit.blade.php
+++ b/resources/views/absensi/edit.blade.php
@@ -4,6 +4,15 @@
 
 @section('content')
 <h1>Edit Absensi</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('absensi.update', $absensi->id) }}" method="POST">
     @csrf @method('PUT')
     <div class="mb-3">
@@ -14,10 +23,12 @@
                 <option value="{{ $s->id }}" @if($absensi->siswa_id == $s->id) selected @endif>{{ $s->nama }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('siswa_id')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Tanggal</label>
         <input type="date" name="tanggal" class="form-control" value="{{ $absensi->tanggal }}" required>
+        <x-input-error :messages="$errors->get('tanggal')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Status</label>
@@ -28,6 +39,7 @@
             <option value="Sakit" @if($absensi->status=='Sakit') selected @endif>Sakit</option>
             <option value="Alpha" @if($absensi->status=='Alpha') selected @endif>Alpha</option>
         </select>
+        <x-input-error :messages="$errors->get('status')" class="mt-1" />
     </div>
     <button class="btn btn-primary">Update</button>
     <a href="{{ route('absensi.index') }}" class="btn btn-secondary">Batal</a>

--- a/resources/views/absensi/harian.blade.php
+++ b/resources/views/absensi/harian.blade.php
@@ -7,6 +7,15 @@
 @if(session('success'))
     <div class="alert alert-success">{{ session('success') }}</div>
 @endif
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form method="GET" class="row g-2 mb-3">
     <div class="col-auto">
         <select name="kelas" class="form-select" onchange="this.form.submit()">

--- a/resources/views/guru/create.blade.php
+++ b/resources/views/guru/create.blade.php
@@ -4,19 +4,31 @@
 
 @section('content')
 <h1>Tambah Guru</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('guru.store') }}" method="POST">
     @csrf
     <div class="mb-3">
         <label>NIP</label>
         <input type="text" name="nip" class="form-control" required>
+        <x-input-error :messages="$errors->get('nip')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Nama</label>
         <input type="text" name="nama" class="form-control" required>
+        <x-input-error :messages="$errors->get('nama')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Tanggal Lahir</label>
         <input type="date" name="tanggal_lahir" class="form-control" required>
+        <x-input-error :messages="$errors->get('tanggal_lahir')" class="mt-1" />
     </div>
     <button class="btn btn-success">Simpan</button>
     <a href="{{ route('guru.index') }}" class="btn btn-secondary">Batal</a>

--- a/resources/views/guru/edit.blade.php
+++ b/resources/views/guru/edit.blade.php
@@ -4,19 +4,31 @@
 
 @section('content')
 <h1>Edit Guru</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('guru.update', $guru->id) }}" method="POST">
     @csrf @method('PUT')
     <div class="mb-3">
         <label>NIP</label>
         <input type="text" name="nip" class="form-control" value="{{ $guru->nip }}" required>
+        <x-input-error :messages="$errors->get('nip')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Nama</label>
         <input type="text" name="nama" class="form-control" value="{{ $guru->nama }}" required>
+        <x-input-error :messages="$errors->get('nama')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Tanggal Lahir</label>
         <input type="date" name="tanggal_lahir" class="form-control" value="{{ $guru->tanggal_lahir }}" required>
+        <x-input-error :messages="$errors->get('tanggal_lahir')" class="mt-1" />
     </div>
     <button class="btn btn-primary">Update</button>
     <a href="{{ route('guru.index') }}" class="btn btn-secondary">Batal</a>

--- a/resources/views/jadwal/create.blade.php
+++ b/resources/views/jadwal/create.blade.php
@@ -7,6 +7,15 @@
 @if(session('error'))
     <div class="alert alert-danger">{{ session('error') }}</div>
 @endif
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('jadwal.store') }}" method="POST">
     @csrf
     <div class="mb-3">
@@ -17,6 +26,7 @@
                 <option value="{{ $k->id }}">{{ $k->nama }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('kelas_id')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Mata Pelajaran</label>
@@ -26,6 +36,7 @@
                 <option value="{{ $m->id }}">{{ $m->nama }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('mapel_id')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Guru</label>
@@ -35,6 +46,7 @@
                 <option value="{{ $g->id }}">{{ $g->nama }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('guru_id')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Hari</label>
@@ -44,14 +56,17 @@
                 <option value="{{ $h }}">{{ $h }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('hari')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Jam Mulai</label>
         <input type="time" name="jam_mulai" class="form-control" required>
+        <x-input-error :messages="$errors->get('jam_mulai')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Jam Selesai</label>
         <input type="time" name="jam_selesai" class="form-control" required>
+        <x-input-error :messages="$errors->get('jam_selesai')" class="mt-1" />
     </div>
     <button class="btn btn-success">Simpan</button>
     <a href="{{ route('jadwal.index') }}" class="btn btn-secondary">Batal</a>

--- a/resources/views/jadwal/edit.blade.php
+++ b/resources/views/jadwal/edit.blade.php
@@ -7,6 +7,15 @@
 @if(session('error'))
     <div class="alert alert-danger">{{ session('error') }}</div>
 @endif
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('jadwal.update', $jadwal->id) }}" method="POST">
     @csrf @method('PUT')
     <div class="mb-3">
@@ -16,6 +25,7 @@
                 <option value="{{ $k->id }}" @selected($k->id==$jadwal->kelas_id)>{{ $k->nama }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('kelas_id')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Mata Pelajaran</label>
@@ -24,6 +34,7 @@
                 <option value="{{ $m->id }}" @selected($m->id==$jadwal->mapel_id)>{{ $m->nama }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('mapel_id')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Guru</label>
@@ -32,6 +43,7 @@
                 <option value="{{ $g->id }}" @selected($g->id==$jadwal->guru_id)>{{ $g->nama }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('guru_id')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Hari</label>
@@ -40,14 +52,17 @@
                 <option value="{{ $h }}" @selected($jadwal->hari==$h)>{{ $h }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('hari')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Jam Mulai</label>
         <input type="time" name="jam_mulai" class="form-control" value="{{ $jadwal->jam_mulai }}" required>
+        <x-input-error :messages="$errors->get('jam_mulai')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Jam Selesai</label>
         <input type="time" name="jam_selesai" class="form-control" value="{{ $jadwal->jam_selesai }}" required>
+        <x-input-error :messages="$errors->get('jam_selesai')" class="mt-1" />
     </div>
     <button class="btn btn-primary">Update</button>
     <a href="{{ route('jadwal.index') }}" class="btn btn-secondary">Batal</a>

--- a/resources/views/kelas/create.blade.php
+++ b/resources/views/kelas/create.blade.php
@@ -4,11 +4,21 @@
 
 @section('content')
 <h1>Tambah Kelas</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('kelas.store') }}" method="POST">
     @csrf
     <div class="mb-3">
         <label>Nama</label>
         <input type="text" name="nama" class="form-control" required>
+        <x-input-error :messages="$errors->get('nama')" class="mt-1" />
     </div>
     <button class="btn btn-success">Simpan</button>
     <a href="{{ route('kelas.index') }}" class="btn btn-secondary">Batal</a>

--- a/resources/views/kelas/edit.blade.php
+++ b/resources/views/kelas/edit.blade.php
@@ -4,11 +4,21 @@
 
 @section('content')
 <h1>Edit Kelas</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('kelas.update', $kela->id) }}" method="POST">
     @csrf @method('PUT')
     <div class="mb-3">
         <label>Nama</label>
         <input type="text" name="nama" class="form-control" value="{{ $kela->nama }}" required>
+        <x-input-error :messages="$errors->get('nama')" class="mt-1" />
     </div>
     <button class="btn btn-primary">Update</button>
     <a href="{{ route('kelas.index') }}" class="btn btn-secondary">Batal</a>

--- a/resources/views/mapel/create.blade.php
+++ b/resources/views/mapel/create.blade.php
@@ -4,11 +4,21 @@
 
 @section('content')
 <h1>Tambah Mata Pelajaran</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('mapel.store') }}" method="POST">
     @csrf
     <div class="mb-3">
         <label>Nama Mapel</label>
         <input type="text" name="nama" class="form-control" required>
+        <x-input-error :messages="$errors->get('nama')" class="mt-1" />
     </div>
     <button class="btn btn-success">Simpan</button>
     <a href="{{ route('mapel.index') }}" class="btn btn-secondary">Batal</a>

--- a/resources/views/mapel/edit.blade.php
+++ b/resources/views/mapel/edit.blade.php
@@ -4,11 +4,21 @@
 
 @section('content')
 <h1>Edit Mata Pelajaran</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('mapel.update', $mapel->id) }}" method="POST">
     @csrf @method('PUT')
     <div class="mb-3">
         <label>Nama Mapel</label>
         <input type="text" name="nama" class="form-control" value="{{ $mapel->nama }}" required>
+        <x-input-error :messages="$errors->get('nama')" class="mt-1" />
     </div>
     <button class="btn btn-primary">Update</button>
     <a href="{{ route('mapel.index') }}" class="btn btn-secondary">Batal</a>

--- a/resources/views/nilai/create.blade.php
+++ b/resources/views/nilai/create.blade.php
@@ -4,6 +4,15 @@
 
 @section('content')
 <h1>Tambah Nilai</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('nilai.store') }}" method="POST">
     @csrf
     <div class="mb-3">
@@ -14,6 +23,7 @@
                 <option value="{{ $s->id }}">{{ $s->nama }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('siswa_id')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Mata Pelajaran</label>
@@ -23,10 +33,12 @@
                 <option value="{{ $m->id }}">{{ $m->nama }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('mapel_id')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Nilai</label>
         <input type="number" name="nilai" class="form-control" min="0" max="100" required>
+        <x-input-error :messages="$errors->get('nilai')" class="mt-1" />
     </div>
     <button class="btn btn-success">Simpan</button>
     <a href="{{ route('nilai.index') }}" class="btn btn-secondary">Batal</a>

--- a/resources/views/nilai/edit.blade.php
+++ b/resources/views/nilai/edit.blade.php
@@ -4,6 +4,15 @@
 
 @section('content')
 <h1>Edit Nilai</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('nilai.update', $nilai->id) }}" method="POST">
     @csrf @method('PUT')
     <div class="mb-3">
@@ -14,6 +23,7 @@
                 <option value="{{ $s->id }}" @if($nilai->siswa_id == $s->id) selected @endif>{{ $s->nama }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('siswa_id')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Mata Pelajaran</label>
@@ -23,10 +33,12 @@
                 <option value="{{ $m->id }}" @if($nilai->mapel_id == $m->id) selected @endif>{{ $m->nama }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('mapel_id')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Nilai</label>
         <input type="number" name="nilai" class="form-control" min="0" max="100" value="{{ $nilai->nilai }}" required>
+        <x-input-error :messages="$errors->get('nilai')" class="mt-1" />
     </div>
     <button class="btn btn-primary">Update</button>
     <a href="{{ route('nilai.index') }}" class="btn btn-secondary">Batal</a>

--- a/resources/views/pengajaran/create.blade.php
+++ b/resources/views/pengajaran/create.blade.php
@@ -7,6 +7,15 @@
 @if(session('error'))
     <div class="alert alert-danger">{{ session('error') }}</div>
 @endif
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('pengajaran.store') }}" method="POST">
     @csrf
     <div class="mb-3">
@@ -17,6 +26,7 @@
                 <option value="{{ $g->nama }}"></option>
             @endforeach
         </datalist>
+        <x-input-error :messages="$errors->get('guru_nama')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Mata Pelajaran</label>
@@ -25,6 +35,7 @@
                 <option value="{{ $m->id }}">{{ $m->nama }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('mapel_id')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Kelas</label>
@@ -33,6 +44,7 @@
                 <option value="{{ $k->nama }}">{{ $k->nama }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('kelas')" class="mt-1" />
     </div>
     <button class="btn btn-success">Simpan</button>
     <a href="{{ route('pengajaran.index') }}" class="btn btn-secondary">Batal</a>

--- a/resources/views/pengajaran/edit.blade.php
+++ b/resources/views/pengajaran/edit.blade.php
@@ -7,6 +7,15 @@
 @if(session('error'))
     <div class="alert alert-danger">{{ session('error') }}</div>
 @endif
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('pengajaran.update', $pengajaran->id) }}" method="POST">
     @csrf @method('PUT')
     <div class="mb-3">
@@ -17,6 +26,7 @@
                 <option value="{{ $g->nama }}"></option>
             @endforeach
         </datalist>
+        <x-input-error :messages="$errors->get('guru_nama')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Mata Pelajaran</label>
@@ -25,6 +35,7 @@
                 <option value="{{ $m->id }}" @selected($pengajaran->mapel_id == $m->id)>{{ $m->nama }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('mapel_id')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Kelas</label>
@@ -33,6 +44,7 @@
                 <option value="{{ $k->nama }}" @selected($pengajaran->kelas == $k->nama)>{{ $k->nama }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('kelas')" class="mt-1" />
     </div>
     <button class="btn btn-primary">Update</button>
     <a href="{{ route('pengajaran.index') }}" class="btn btn-secondary">Batal</a>

--- a/resources/views/siswa/absen.blade.php
+++ b/resources/views/siswa/absen.blade.php
@@ -7,6 +7,15 @@
 @if(session('success'))
     <div class="alert alert-success">{{ session('success') }}</div>
 @endif
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('student.absen') }}" method="POST">
     @csrf
     <div class="mb-3">
@@ -18,6 +27,7 @@
             <option value="Sakit">Sakit</option>
             <option value="Alpha">Alpha</option>
         </select>
+        <x-input-error :messages="$errors->get('status')" class="mt-1" />
     </div>
     <button class="btn btn-success">Simpan</button>
     <a href="{{ route('student.absensi') }}" class="btn btn-secondary">Kembali</a>

--- a/resources/views/siswa/create.blade.php
+++ b/resources/views/siswa/create.blade.php
@@ -4,15 +4,26 @@
 
 @section('content')
 <h1>Tambah Siswa</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('siswa.store') }}" method="POST">
     @csrf
     <div class="mb-3">
         <label>Nama</label>
         <input type="text" name="nama" class="form-control" required>
+        <x-input-error :messages="$errors->get('nama')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>NISN</label>
         <input type="text" name="nisn" class="form-control" required>
+        <x-input-error :messages="$errors->get('nisn')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Kelas</label>
@@ -22,10 +33,12 @@
                 <option value="{{ $k->nama }}">{{ $k->nama }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('kelas')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Tanggal Lahir</label>
         <input type="date" name="tanggal_lahir" class="form-control" required>
+        <x-input-error :messages="$errors->get('tanggal_lahir')" class="mt-1" />
     </div>
     <button class="btn btn-success">Simpan</button>
     <a href="{{ route('siswa.index') }}" class="btn btn-secondary">Batal</a>

--- a/resources/views/siswa/edit.blade.php
+++ b/resources/views/siswa/edit.blade.php
@@ -4,15 +4,26 @@
 
 @section('content')
 <h1>Edit Siswa</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('siswa.update', $siswa->id) }}" method="POST">
     @csrf @method('PUT')
     <div class="mb-3">
         <label>Nama</label>
         <input type="text" name="nama" class="form-control" value="{{ $siswa->nama }}" required>
+        <x-input-error :messages="$errors->get('nama')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>NISN</label>
         <input type="text" name="nisn" class="form-control" value="{{ $siswa->nisn }}" required>
+        <x-input-error :messages="$errors->get('nisn')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Kelas</label>
@@ -22,10 +33,12 @@
                 <option value="{{ $k->nama }}" {{ $siswa->kelas == $k->nama ? 'selected' : '' }}>{{ $k->nama }}</option>
             @endforeach
         </select>
+        <x-input-error :messages="$errors->get('kelas')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Tanggal Lahir</label>
         <input type="date" name="tanggal_lahir" class="form-control" value="{{ $siswa->tanggal_lahir }}" required>
+        <x-input-error :messages="$errors->get('tanggal_lahir')" class="mt-1" />
     </div>
     <button class="btn btn-primary">Update</button>
     <a href="{{ route('siswa.index') }}" class="btn btn-secondary">Batal</a>

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -4,6 +4,15 @@
 
 @section('content')
 <h1>Tambah User</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('users.store') }}" method="POST">
     @csrf
     <div class="mb-3">
@@ -13,22 +22,27 @@
             <option value="guru">guru</option>
             <option value="siswa">siswa</option>
         </select>
+        <x-input-error :messages="$errors->get('role')" class="mt-1" />
     </div>
     <div class="mb-3" id="field-name">
         <label>Nama</label>
         <input type="text" name="name" class="form-control">
+        <x-input-error :messages="$errors->get('name')" class="mt-1" />
     </div>
     <div class="mb-3" id="field-email">
         <label>Email</label>
         <input type="email" name="email" class="form-control">
+        <x-input-error :messages="$errors->get('email')" class="mt-1" />
     </div>
     <div class="mb-3" id="field-password">
         <label>Password</label>
         <input type="password" name="password" class="form-control">
+        <x-input-error :messages="$errors->get('password')" class="mt-1" />
     </div>
     <div class="mb-3" id="field-password-confirm">
         <label>Konfirmasi Password</label>
         <input type="password" name="password_confirmation" class="form-control">
+        <x-input-error :messages="$errors->get('password_confirmation')" class="mt-1" />
     </div>
     <input type="hidden" name="guru_id" id="guru-id">
     <input type="hidden" name="siswa_id" id="siswa-id">

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -4,6 +4,15 @@
 
 @section('content')
 <h1>Edit User</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 <form action="{{ route('users.update', $user->id) }}" method="POST">
     @csrf @method('PUT')
     <div class="mb-3">
@@ -14,23 +23,28 @@
             <option value="siswa" @selected($user->role=='siswa')>siswa</option>
         </select>
         <input type="hidden" name="role" value="{{ $user->role }}">
+        <x-input-error :messages="$errors->get('role')" class="mt-1" />
     </div>
     <div class="mb-3" id="field-name">
         <label>Nama</label>
         <input type="text" name="name" class="form-control" value="{{ $user->name }}" disabled>
         <input type="hidden" name="name" value="{{ $user->name }}">
+        <x-input-error :messages="$errors->get('name')" class="mt-1" />
     </div>
     <div class="mb-3" id="field-email">
         <label>Email</label>
         <input type="email" name="email" class="form-control" value="{{ $user->email }}">
+        <x-input-error :messages="$errors->get('email')" class="mt-1" />
     </div>
     <div class="mb-3" id="field-password">
         <label>Password (isi jika ingin ganti)</label>
         <input type="password" name="password" class="form-control">
+        <x-input-error :messages="$errors->get('password')" class="mt-1" />
     </div>
     <div class="mb-3" id="field-password-confirm">
         <label>Konfirmasi Password</label>
         <input type="password" name="password_confirmation" class="form-control">
+        <x-input-error :messages="$errors->get('password_confirmation')" class="mt-1" />
     </div>
     <input type="hidden" name="guru_id" id="guru-id" value="{{ optional($guru->firstWhere('user_id', $user->id))->id }}">
     <input type="hidden" name="siswa_id" id="siswa-id" value="{{ optional($siswa->firstWhere('user_id', $user->id))->id }}">


### PR DESCRIPTION
## Summary
- show validation error lists on top of forms
- display field level validation errors for all data entry pages

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a1756f140832ba94f90ab7c12c048