### PR TITLE
Fix sidebar visibility on large screens

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -106,6 +106,20 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    <script>
+        function handleSidebar() {
+            var sidebar = document.getElementById('sidebar');
+            if (!sidebar) return;
+            var instance = bootstrap.Offcanvas.getOrCreateInstance(sidebar);
+            if (window.innerWidth >= 992) {
+                instance.show();
+            } else {
+                instance.hide();
+            }
+        }
+        window.addEventListener('load', handleSidebar);
+        window.addEventListener('resize', handleSidebar);
+    </script>
     @yield('scripts')
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure Bootstrap offcanvas sidebar displays by default on large screens
- add script to toggle sidebar based on window width

## Testing
- `phpunit` *(fails: `phpunit: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686a27f9a198832b83bf5379d816f2c9