### PR TITLE
Show sidebar automatically

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -107,18 +107,13 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <script>
-        function handleSidebar() {
+        function showSidebar() {
             var sidebar = document.getElementById('sidebar');
             if (!sidebar) return;
             var instance = bootstrap.Offcanvas.getOrCreateInstance(sidebar);
-            if (window.innerWidth >= 992) {
-                instance.show();
-            } else {
-                instance.hide();
-            }
+            instance.show();
         }
-        window.addEventListener('load', handleSidebar);
-        window.addEventListener('resize', handleSidebar);
+        window.addEventListener('load', showSidebar);
     </script>
     @yield('scripts')
 </body>


### PR DESCRIPTION
## Summary
- always show the sidebar on load so users don't have to click the brand link first

## Testing
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686a29b9292c832b82b1590c2218bcf8