### PR TITLE
Prevent sidebar auto-closing

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -36,7 +36,7 @@
         </div>
     </nav>
     @auth
-    <div class="offcanvas offcanvas-start offcanvas-lg" tabindex="-1" id="sidebar" aria-labelledby="sidebarLabel" style="--bs-offcanvas-width: 260px;">
+    <div class="offcanvas offcanvas-start offcanvas-lg" tabindex="-1" id="sidebar" aria-labelledby="sidebarLabel" data-bs-backdrop="static" style="--bs-offcanvas-width: 260px;">
         <div class="offcanvas-header">
             <h5 class="offcanvas-title" id="sidebarLabel">Menu</h5>
             <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>


### PR DESCRIPTION
## Summary
- keep sidebar open by setting `data-bs-backdrop="static"`

## Testing
- `composer install --no-interaction --no-progress` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a33f2c2e0832b89996adf76bd59b4