### PR TITLE
Fix sidebar visibility on desktop

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -12,7 +12,7 @@
     <nav class="navbar navbar-dark bg-dark mb-4">
         <div class="container">
         @auth
-            <button class="navbar-toggler me-2 d-lg-none" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebar" aria-controls="sidebar">
+            <button class="navbar-toggler me-2 d-block" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebar" aria-controls="sidebar">
                 <span class="navbar-toggler-icon"></span>
             </button>
         @endauth
@@ -116,6 +116,15 @@
             } else {
                 instance.hide();
             }
+        }
+        var sidebar = document.getElementById('sidebar');
+        if (sidebar) {
+            sidebar.addEventListener('hidden.bs.offcanvas', function () {
+                if (window.innerWidth >= 992) {
+                    var instance = bootstrap.Offcanvas.getOrCreateInstance(sidebar);
+                    instance.show();
+                }
+            });
         }
         window.addEventListener('load', handleSidebar);
         window.addEventListener('resize', handleSidebar);


### PR DESCRIPTION
## Summary
- keep sidebar toggler visible on large screens
- restore the sidebar automatically if hidden while desktop width

## Testing
- `php artisan test` *(fails: Tests\Feature\JadwalPengajaranSyncTest > store jadwal updates pengajaran if subject and class exist)*

------
https://chatgpt.com/codex/tasks/task_e_686a35afcabc832b8ce869ca7fa00faf