### PR TITLE
Remove sidebar auto-show event

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -118,14 +118,6 @@
             }
         }
         var sidebar = document.getElementById('sidebar');
-        if (sidebar) {
-            sidebar.addEventListener('hidden.bs.offcanvas', function () {
-                if (window.innerWidth >= 992) {
-                    var instance = bootstrap.Offcanvas.getOrCreateInstance(sidebar);
-                    instance.show();
-                }
-            });
-        }
         window.addEventListener('load', handleSidebar);
         window.addEventListener('resize', handleSidebar);
     </script>


### PR DESCRIPTION
## Summary
- delete offcanvas `hidden.bs.offcanvas` handler so sidebar won't reopen automatically

## Testing
- `npm install`
- `npm run build`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686a3c988400832b9a50b8e679a33bc7