### PR TITLE
Add birthplace & gender fields for Guru and Siswa

### DIFF
--- a/app/Exports/SiswaExport.php
+++ b/app/Exports/SiswaExport.php
@@ -10,7 +10,7 @@ class SiswaExport implements FromCollection, WithHeadings
 {
     public function collection()
     {
-        return Siswa::select('id', 'nama', 'nisn', 'kelas', 'tanggal_lahir')->get();
+        return Siswa::select('id', 'nama', 'nisn', 'kelas', 'tempat_lahir', 'jenis_kelamin', 'tanggal_lahir')->get();
     }
 
     public function headings(): array
@@ -20,6 +20,8 @@ class SiswaExport implements FromCollection, WithHeadings
             'Nama',
             'NISN',
             'Kelas',
+            'Tempat Lahir',
+            'Jenis Kelamin',
             'Tanggal Lahir',
         ];
     }

--- a/app/Http/Controllers/GuruController.php
+++ b/app/Http/Controllers/GuruController.php
@@ -15,7 +15,7 @@ class GuruController extends Controller
         if ($search) {
             $query->where(function ($q) use ($search) {
                 $q->where('nama', 'like', "%{$search}%")
-                    ->orWhere('nip', 'like', "%{$search}%");
+                    ->orWhere('nuptk', 'like', "%{$search}%");
             });
         }
 
@@ -32,8 +32,10 @@ public function create()
 public function store(Request $request)
 {
     Guru::create($request->validate([
-        'nip' => 'required|unique:guru',
+        'nuptk' => 'required|unique:guru',
         'nama' => 'required',
+        'tempat_lahir' => 'required',
+        'jenis_kelamin' => 'required',
         'tanggal_lahir' => 'required|date'
     ]));
 
@@ -48,8 +50,10 @@ public function edit(Guru $guru)
 public function update(Request $request, Guru $guru)
 {
     $guru->update($request->validate([
-        'nip' => 'required|unique:guru,nip,' . $guru->id,
+        'nuptk' => 'required|unique:guru,nuptk,' . $guru->id,
         'nama' => 'required',
+        'tempat_lahir' => 'required',
+        'jenis_kelamin' => 'required',
         'tanggal_lahir' => 'required|date'
     ]));
 

--- a/app/Http/Controllers/SiswaController.php
+++ b/app/Http/Controllers/SiswaController.php
@@ -40,6 +40,8 @@ public function store(Request $request)
         'nama' => 'required',
         'nisn' => 'required|unique:siswa,nisn',
         'kelas' => 'required',
+        'tempat_lahir' => 'required',
+        'jenis_kelamin' => 'required',
         'tanggal_lahir' => 'required|date'
     ]));
 
@@ -58,6 +60,8 @@ public function update(Request $request, Siswa $siswa)
         'nama' => 'required',
         'nisn' => 'required|unique:siswa,nisn,' . $siswa->id,
         'kelas' => 'required',
+        'tempat_lahir' => 'required',
+        'jenis_kelamin' => 'required',
         'tanggal_lahir' => 'required|date'
     ]));
 

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -49,8 +49,8 @@ class UserController extends Controller
 
         if ($data['role'] === 'guru') {
             $guru = Guru::findOrFail($data['guru_id']);
-            $name = $guru->nip.' - '.$guru->nama;
-            $email = $guru->nip.'@muhammadiyah.ac.id';
+            $name = $guru->nuptk.' - '.$guru->nama;
+            $email = $guru->nuptk.'@muhammadiyah.ac.id';
             $password = Carbon::parse($guru->tanggal_lahir)->format('ymd');
         } elseif ($data['role'] === 'siswa') {
             $siswa = Siswa::findOrFail($data['siswa_id']);

--- a/app/Models/Guru.php
+++ b/app/Models/Guru.php
@@ -10,7 +10,14 @@ class Guru extends Model
     use HasFactory;
 
     protected $table = 'guru';
-    protected $fillable = ['nip', 'nama', 'tanggal_lahir', 'user_id'];
+    protected $fillable = [
+        'nuptk',
+        'nama',
+        'tempat_lahir',
+        'jenis_kelamin',
+        'tanggal_lahir',
+        'user_id'
+    ];
 
     public function user()
     {

--- a/app/Models/Siswa.php
+++ b/app/Models/Siswa.php
@@ -10,7 +10,15 @@ class Siswa extends Model
     use HasFactory;
 
     protected $table = 'siswa';
-    protected $fillable = ['nama', 'nisn', 'kelas', 'tanggal_lahir', 'user_id'];
+    protected $fillable = [
+        'nama',
+        'nisn',
+        'kelas',
+        'tempat_lahir',
+        'jenis_kelamin',
+        'tanggal_lahir',
+        'user_id'
+    ];
 
     public function user()
     {

--- a/database/migrations/2025_07_05_000001_update_guru_and_siswa_tables.php
+++ b/database/migrations/2025_07_05_000001_update_guru_and_siswa_tables.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('guru', function (Blueprint $table) {
+            $table->renameColumn('nip', 'nuptk');
+            $table->string('tempat_lahir')->after('nama');
+            $table->string('jenis_kelamin')->after('tempat_lahir');
+        });
+        Schema::table('siswa', function (Blueprint $table) {
+            $table->string('tempat_lahir')->after('kelas');
+            $table->string('jenis_kelamin')->after('tempat_lahir');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('guru', function (Blueprint $table) {
+            $table->renameColumn('nuptk', 'nip');
+            $table->dropColumn(['tempat_lahir', 'jenis_kelamin']);
+        });
+        Schema::table('siswa', function (Blueprint $table) {
+            $table->dropColumn(['tempat_lahir', 'jenis_kelamin']);
+        });
+    }
+};

--- a/database/seeders/GuruSeeder.php
+++ b/database/seeders/GuruSeeder.php
@@ -16,8 +16,10 @@ class GuruSeeder extends Seeder
         $guruUser = User::where('email', 'guru@demo.com')->first();
         for ($i = 1; $i <= 20; $i++) {
             $data[] = [
-                'nip' => str_pad($i, 18, '0', STR_PAD_LEFT),
+                'nuptk' => str_pad($i, 18, '0', STR_PAD_LEFT),
                 'nama' => $i === 1 ? 'Guru' : $faker->unique()->name,
+                'tempat_lahir' => $faker->city,
+                'jenis_kelamin' => $faker->randomElement(['L', 'P']),
                 'tanggal_lahir' => $faker->dateTimeBetween('1980-01-01', '1995-12-31')->format('Y-m-d'),
                 'user_id' => $i === 1 && $guruUser ? $guruUser->id : null,
             ];

--- a/database/seeders/SiswaSeeder.php
+++ b/database/seeders/SiswaSeeder.php
@@ -19,6 +19,8 @@ class SiswaSeeder extends Seeder
                 'nama' => $i === 1 ? 'Siswa' : $faker->unique()->name,
                 'nisn' => $faker->unique()->numerify('############'),
                 'kelas' => '10' . chr(64 + ($i % 3) + 1),
+                'tempat_lahir' => $faker->city,
+                'jenis_kelamin' => $faker->randomElement(['L', 'P']),
                 'tanggal_lahir' => $faker->dateTimeBetween('2008-01-01', '2008-12-31')->format('Y-m-d'),
                 'user_id' => $i === 1 && $siswaUser ? $siswaUser->id : null,
             ];

--- a/resources/views/guru/create.blade.php
+++ b/resources/views/guru/create.blade.php
@@ -16,14 +16,28 @@
 <form action="{{ route('guru.store') }}" method="POST">
     @csrf
     <div class="mb-3">
-        <label>NIP</label>
-        <input type="text" name="nip" class="form-control" required>
-        <x-input-error :messages="$errors->get('nip')" class="mt-1" />
+        <label>NUPTK</label>
+        <input type="text" name="nuptk" class="form-control" required>
+        <x-input-error :messages="$errors->get('nuptk')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Nama</label>
         <input type="text" name="nama" class="form-control" required>
         <x-input-error :messages="$errors->get('nama')" class="mt-1" />
+    </div>
+    <div class="mb-3">
+        <label>Tempat Lahir</label>
+        <input type="text" name="tempat_lahir" class="form-control" required>
+        <x-input-error :messages="$errors->get('tempat_lahir')" class="mt-1" />
+    </div>
+    <div class="mb-3">
+        <label>Jenis Kelamin</label>
+        <select name="jenis_kelamin" class="form-control" required>
+            <option value="">-- Pilih --</option>
+            <option value="L">Laki-laki</option>
+            <option value="P">Perempuan</option>
+        </select>
+        <x-input-error :messages="$errors->get('jenis_kelamin')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Tanggal Lahir</label>

--- a/resources/views/guru/edit.blade.php
+++ b/resources/views/guru/edit.blade.php
@@ -16,14 +16,28 @@
 <form action="{{ route('guru.update', $guru->id) }}" method="POST">
     @csrf @method('PUT')
     <div class="mb-3">
-        <label>NIP</label>
-        <input type="text" name="nip" class="form-control" value="{{ $guru->nip }}" required>
-        <x-input-error :messages="$errors->get('nip')" class="mt-1" />
+        <label>NUPTK</label>
+        <input type="text" name="nuptk" class="form-control" value="{{ $guru->nuptk }}" required>
+        <x-input-error :messages="$errors->get('nuptk')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Nama</label>
         <input type="text" name="nama" class="form-control" value="{{ $guru->nama }}" required>
         <x-input-error :messages="$errors->get('nama')" class="mt-1" />
+    </div>
+    <div class="mb-3">
+        <label>Tempat Lahir</label>
+        <input type="text" name="tempat_lahir" class="form-control" value="{{ $guru->tempat_lahir }}" required>
+        <x-input-error :messages="$errors->get('tempat_lahir')" class="mt-1" />
+    </div>
+    <div class="mb-3">
+        <label>Jenis Kelamin</label>
+        <select name="jenis_kelamin" class="form-control" required>
+            <option value="">-- Pilih --</option>
+            <option value="L" {{ $guru->jenis_kelamin == 'L' ? 'selected' : '' }}>Laki-laki</option>
+            <option value="P" {{ $guru->jenis_kelamin == 'P' ? 'selected' : '' }}>Perempuan</option>
+        </select>
+        <x-input-error :messages="$errors->get('jenis_kelamin')" class="mt-1" />
     </div>
     <div class="mb-3">
         <label>Tanggal Lahir</label>

--- a/resources/views/guru/index.blade.php
+++ b/resources/views/guru/index.blade.php
@@ -18,8 +18,10 @@
     <thead>
         <tr>
             <th>ID</th>
-            <th>NIP</th>
+            <th>NUPTK</th>
             <th>Nama</th>
+            <th>Tempat Lahir</th>
+            <th>Jenis Kelamin</th>
             <th>Tanggal Lahir</th>
             <th>Aksi</th>
         </tr>
@@ -28,8 +30,10 @@
         @foreach ($guru as $g)
         <tr>
             <td>{{ $g->id }}</td>
-            <td>{{ $g->nip }}</td>
+            <td>{{ $g->nuptk }}</td>
             <td>{{ $g->nama }}</td>
+            <td>{{ $g->tempat_lahir }}</td>
+            <td>{{ $g->jenis_kelamin }}</td>
             <td>{{ $g->tanggal_lahir }}</td>
             <td>
                 <a href="{{ route('guru.edit', $g->id) }}" class="btn btn-sm btn-warning">Edit</a>

--- a/resources/views/guru/kelas.blade.php
+++ b/resources/views/guru/kelas.blade.php
@@ -20,6 +20,8 @@
         <tr>
             <th>Nama</th>
             <th>NISN</th>
+            <th>Tempat Lahir</th>
+            <th>Jenis Kelamin</th>
             <th>Tanggal Lahir</th>
             <th>Aksi</th>
         </tr>
@@ -29,6 +31,8 @@
         <tr>
             <td>{{ $s->nama }}</td>
             <td>{{ $s->nisn }}</td>
+            <td>{{ $s->tempat_lahir }}</td>
+            <td>{{ $s->jenis_kelamin }}</td>
             <td>{{ $s->tanggal_lahir }}</td>
             <td>
                 <a href="{{ route('rapor.cetak', $s->id) }}" class="btn btn-sm btn-info" target="_blank">Cetak Rapor</a>

--- a/resources/views/siswa/create.blade.php
+++ b/resources/views/siswa/create.blade.php
@@ -36,6 +36,20 @@
         <x-input-error :messages="$errors->get('kelas')" class="mt-1" />
     </div>
     <div class="mb-3">
+        <label>Tempat Lahir</label>
+        <input type="text" name="tempat_lahir" class="form-control" required>
+        <x-input-error :messages="$errors->get('tempat_lahir')" class="mt-1" />
+    </div>
+    <div class="mb-3">
+        <label>Jenis Kelamin</label>
+        <select name="jenis_kelamin" class="form-control" required>
+            <option value="">-- Pilih --</option>
+            <option value="L">Laki-laki</option>
+            <option value="P">Perempuan</option>
+        </select>
+        <x-input-error :messages="$errors->get('jenis_kelamin')" class="mt-1" />
+    </div>
+    <div class="mb-3">
         <label>Tanggal Lahir</label>
         <input type="date" name="tanggal_lahir" class="form-control" required>
         <x-input-error :messages="$errors->get('tanggal_lahir')" class="mt-1" />

--- a/resources/views/siswa/edit.blade.php
+++ b/resources/views/siswa/edit.blade.php
@@ -36,6 +36,20 @@
         <x-input-error :messages="$errors->get('kelas')" class="mt-1" />
     </div>
     <div class="mb-3">
+        <label>Tempat Lahir</label>
+        <input type="text" name="tempat_lahir" class="form-control" value="{{ $siswa->tempat_lahir }}" required>
+        <x-input-error :messages="$errors->get('tempat_lahir')" class="mt-1" />
+    </div>
+    <div class="mb-3">
+        <label>Jenis Kelamin</label>
+        <select name="jenis_kelamin" class="form-control" required>
+            <option value="">-- Pilih --</option>
+            <option value="L" {{ $siswa->jenis_kelamin == 'L' ? 'selected' : '' }}>Laki-laki</option>
+            <option value="P" {{ $siswa->jenis_kelamin == 'P' ? 'selected' : '' }}>Perempuan</option>
+        </select>
+        <x-input-error :messages="$errors->get('jenis_kelamin')" class="mt-1" />
+    </div>
+    <div class="mb-3">
         <label>Tanggal Lahir</label>
         <input type="date" name="tanggal_lahir" class="form-control" value="{{ $siswa->tanggal_lahir }}" required>
         <x-input-error :messages="$errors->get('tanggal_lahir')" class="mt-1" />

--- a/resources/views/siswa/index.blade.php
+++ b/resources/views/siswa/index.blade.php
@@ -22,6 +22,8 @@
             <th>Nama</th>
             <th>NISN</th>
             <th>Kelas</th>
+            <th>Tempat Lahir</th>
+            <th>Jenis Kelamin</th>
             <th>Tanggal Lahir</th>
             <th>Aksi</th>
         </tr>
@@ -33,6 +35,8 @@
             <td>{{ $s->nama }}</td>
             <td>{{ $s->nisn }}</td>
             <td>{{ $s->kelas }}</td>
+            <td>{{ $s->tempat_lahir }}</td>
+            <td>{{ $s->jenis_kelamin }}</td>
             <td>{{ $s->tanggal_lahir }}</td>
             <td>
                 <a href="{{ route('siswa.edit', $s->id) }}" class="btn btn-sm btn-warning">Edit</a>

--- a/resources/views/siswa/show.blade.php
+++ b/resources/views/siswa/show.blade.php
@@ -8,6 +8,8 @@
     <tr><th>Nama</th><td>{{ $siswa->nama }}</td></tr>
     <tr><th>NISN</th><td>{{ $siswa->nisn }}</td></tr>
     <tr><th>Kelas</th><td>{{ $siswa->kelas }}</td></tr>
+    <tr><th>Tempat Lahir</th><td>{{ $siswa->tempat_lahir }}</td></tr>
+    <tr><th>Jenis Kelamin</th><td>{{ $siswa->jenis_kelamin }}</td></tr>
     <tr><th>Tanggal Lahir</th><td>{{ $siswa->tanggal_lahir }}</td></tr>
 </table>
 @endsection

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -48,7 +48,7 @@
     <input type="hidden" name="siswa_id" id="siswa-id">
     <datalist id="guru-list">
         @foreach ($guru as $g)
-            <option value="{{ $g->nip }} - {{ $g->nama }}" data-id="{{ $g->id }}" data-nip="{{ $g->nip }}" data-tanggallahir="{{ $g->tanggal_lahir }}"></option>
+            <option value="{{ $g->nuptk }} - {{ $g->nama }}" data-id="{{ $g->id }}" data-nuptk="{{ $g->nuptk }}" data-tanggallahir="{{ $g->tanggal_lahir }}"></option>
         @endforeach
     </datalist>
     <datalist id="siswa-list">
@@ -70,7 +70,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const siswaId = document.getElementById('siswa-id');
 
     function setFromOption(opt, type) {
-        const id = type === 'guru' ? opt.dataset.nip : opt.dataset.nisn;
+        const id = type === 'guru' ? opt.dataset.nuptk : opt.dataset.nisn;
         const tgl = opt.dataset.tanggallahir || '';
         if (id) {
             emailInput.value = id + '@muhammadiyah.ac.id';

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -50,7 +50,7 @@
     <input type="hidden" name="siswa_id" id="siswa-id" value="{{ optional($siswa->firstWhere('user_id', $user->id))->id }}">
     <datalist id="guru-list">
         @foreach ($guru as $g)
-            <option value="{{ $g->nip }} - {{ $g->nama }}" data-id="{{ $g->id }}" data-nip="{{ $g->nip }}" data-tanggallahir="{{ $g->tanggal_lahir }}"></option>
+            <option value="{{ $g->nuptk }} - {{ $g->nama }}" data-id="{{ $g->id }}" data-nuptk="{{ $g->nuptk }}" data-tanggallahir="{{ $g->tanggal_lahir }}"></option>
         @endforeach
     </datalist>
     <datalist id="siswa-list">
@@ -72,7 +72,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const siswaId = document.getElementById('siswa-id');
 
     function setFromOption(opt, type) {
-        const id = type === 'guru' ? opt.dataset.nip : opt.dataset.nisn;
+        const id = type === 'guru' ? opt.dataset.nuptk : opt.dataset.nisn;
         const tgl = opt.dataset.tanggallahir || '';
         if (id) {
             emailInput.value = id + '@muhammadiyah.ac.id';

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -19,12 +19,16 @@ class DashboardTest extends TestCase
             'nama' => 'Test1',
             'nisn' => '0000000001',
             'kelas' => '10A',
+            'tempat_lahir' => 'Bandung',
+            'jenis_kelamin' => 'L',
             'tanggal_lahir' => '2000-01-01'
         ]);
         Siswa::create([
             'nama' => 'Test2',
             'nisn' => '0000000002',
             'kelas' => '10B',
+            'tempat_lahir' => 'Jakarta',
+            'jenis_kelamin' => 'P',
             'tanggal_lahir' => '2000-01-02'
         ]);
 

--- a/tests/Feature/JadwalConflictTest.php
+++ b/tests/Feature/JadwalConflictTest.php
@@ -18,8 +18,10 @@ class JadwalConflictTest extends TestCase
     {
         $user = User::factory()->create(['role' => 'admin']);
         $guru = Guru::create([
-            'nip' => '111',
+            'nuptk' => '111',
             'nama' => 'Guru A',
+            'tempat_lahir' => 'Bandung',
+            'jenis_kelamin' => 'L',
             'tanggal_lahir' => '1980-01-01',
         ]);
         $mapel = MataPelajaran::create(['nama' => 'Matematika']);
@@ -56,8 +58,10 @@ class JadwalConflictTest extends TestCase
     {
         $user = User::factory()->create(['role' => 'admin']);
         $guru = Guru::create([
-            'nip' => '222',
+            'nuptk' => '222',
             'nama' => 'Guru B',
+            'tempat_lahir' => 'Jakarta',
+            'jenis_kelamin' => 'L',
             'tanggal_lahir' => '1985-01-01',
         ]);
         $mapel = MataPelajaran::create(['nama' => 'IPA']);

--- a/tests/Feature/JadwalPengajaranSyncTest.php
+++ b/tests/Feature/JadwalPengajaranSyncTest.php
@@ -18,8 +18,10 @@ class JadwalPengajaranSyncTest extends TestCase
     {
         $user = User::factory()->create(['role' => 'admin']);
         $guru = Guru::create([
-            'nip' => '123',
+            'nuptk' => '123',
             'nama' => 'Guru Test',
+            'tempat_lahir' => 'Jakarta',
+            'jenis_kelamin' => 'L',
             'tanggal_lahir' => '1980-01-01',
         ]);
         $mapel = MataPelajaran::create(['nama' => 'Matematika']);
@@ -46,13 +48,17 @@ class JadwalPengajaranSyncTest extends TestCase
     {
         $user = User::factory()->create(['role' => 'admin']);
         $guruA = Guru::create([
-            'nip' => '111',
+            'nuptk' => '111',
             'nama' => 'Guru A',
+            'tempat_lahir' => 'Bandung',
+            'jenis_kelamin' => 'L',
             'tanggal_lahir' => '1980-01-01',
         ]);
         $guruB = Guru::create([
-            'nip' => '222',
+            'nuptk' => '222',
             'nama' => 'Guru B',
+            'tempat_lahir' => 'Jakarta',
+            'jenis_kelamin' => 'L',
             'tanggal_lahir' => '1985-01-01',
         ]);
         $mapel = MataPelajaran::create(['nama' => 'IPA']);

--- a/tests/Feature/JadwalPengajaranTeacherLockTest.php
+++ b/tests/Feature/JadwalPengajaranTeacherLockTest.php
@@ -19,13 +19,17 @@ class JadwalPengajaranTeacherLockTest extends TestCase
     {
         $user = User::factory()->create(['role' => 'admin']);
         $guruA = Guru::create([
-            'nip' => '5001',
+            'nuptk' => '5001',
             'nama' => 'Guru A',
+            'tempat_lahir' => 'Bandung',
+            'jenis_kelamin' => 'L',
             'tanggal_lahir' => '1980-01-01',
         ]);
         $guruB = Guru::create([
-            'nip' => '5002',
+            'nuptk' => '5002',
             'nama' => 'Guru B',
+            'tempat_lahir' => 'Jakarta',
+            'jenis_kelamin' => 'L',
             'tanggal_lahir' => '1985-01-01',
         ]);
         $mapel = MataPelajaran::create(['nama' => 'Bahasa Indonesia']);

--- a/tests/Feature/JadwalValidationTest.php
+++ b/tests/Feature/JadwalValidationTest.php
@@ -18,8 +18,10 @@ class JadwalValidationTest extends TestCase
     {
         $user = User::factory()->create(['role' => 'admin']);
         $guru = Guru::create([
-            'nip' => '999',
+            'nuptk' => '999',
             'nama' => 'Guru Test',
+            'tempat_lahir' => 'Bandung',
+            'jenis_kelamin' => 'L',
             'tanggal_lahir' => '1990-01-01',
         ]);
         $mapel = MataPelajaran::create(['nama' => 'Matematika']);

--- a/tests/Feature/PengajaranUniqueTest.php
+++ b/tests/Feature/PengajaranUniqueTest.php
@@ -18,13 +18,17 @@ class PengajaranUniqueTest extends TestCase
     {
         $user = User::factory()->create(['role' => 'admin']);
         $guruA = Guru::create([
-            'nip' => '1001',
+            'nuptk' => '1001',
             'nama' => 'Guru A',
+            'tempat_lahir' => 'Bandung',
+            'jenis_kelamin' => 'L',
             'tanggal_lahir' => '1980-01-01',
         ]);
         $guruB = Guru::create([
-            'nip' => '1002',
+            'nuptk' => '1002',
             'nama' => 'Guru B',
+            'tempat_lahir' => 'Jakarta',
+            'jenis_kelamin' => 'L',
             'tanggal_lahir' => '1985-01-01',
         ]);
         $mapel = MataPelajaran::create(['nama' => 'Matematika']);


### PR DESCRIPTION
## Summary
- migrate Guru->nip to nuptk and add birthplace & gender columns for both Guru and Siswa
- expose new fields in models, controllers and seeders
- update user creation logic to use nuptk
- adjust forms and listings for new fields
- update tests for renamed/added columns

## Testing
- `composer install` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a42a454b0832ba114a9d364aa6e8b