### PR TITLE
Fix rename column syntax for MariaDB

### DIFF
--- a/database/migrations/2025_07_05_000001_update_guru_and_siswa_tables.php
+++ b/database/migrations/2025_07_05_000001_update_guru_and_siswa_tables.php
@@ -3,12 +3,17 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
 
 return new class extends Migration {
     public function up(): void
     {
+        // Older MariaDB versions (<10.5) do not support the "RENAME COLUMN"
+        // syntax used by Laravel's renameColumn method. Instead we manually
+        // issue a "CHANGE" statement to ensure compatibility.
+        DB::statement('ALTER TABLE guru CHANGE nip nuptk VARCHAR(255)');
+
         Schema::table('guru', function (Blueprint $table) {
-            $table->renameColumn('nip', 'nuptk');
             $table->string('tempat_lahir')->after('nama');
             $table->string('jenis_kelamin')->after('tempat_lahir');
         });
@@ -20,8 +25,8 @@ return new class extends Migration {
 
     public function down(): void
     {
+        DB::statement('ALTER TABLE guru CHANGE nuptk nip VARCHAR(255)');
         Schema::table('guru', function (Blueprint $table) {
-            $table->renameColumn('nuptk', 'nip');
             $table->dropColumn(['tempat_lahir', 'jenis_kelamin']);
         });
         Schema::table('siswa', function (Blueprint $table) {


### PR DESCRIPTION
## Summary
- adjust migration to use `CHANGE` syntax for MariaDB

## Testing
- `php -l database/migrations/2025_07_05_000001_update_guru_and_siswa_tables.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686a4567ca94832b9d880100a15f4d15