### PR TITLE
Enable pagination for index pages

### DIFF
--- a/app/Http/Controllers/AbsensiController.php
+++ b/app/Http/Controllers/AbsensiController.php
@@ -46,7 +46,7 @@ class AbsensiController extends Controller
             });
         }
 
-        $absensi = $query->get();
+        $absensi = $query->paginate(10)->withQueryString();
 
         return view('absensi.index', compact('absensi', 'search'));
     }

--- a/app/Http/Controllers/GuruController.php
+++ b/app/Http/Controllers/GuruController.php
@@ -19,7 +19,7 @@ class GuruController extends Controller
             });
         }
 
-        $guru = $query->get();
+        $guru = $query->paginate(10)->withQueryString();
 
         return view('guru.index', compact('guru', 'search'));
     }

--- a/app/Http/Controllers/KelasController.php
+++ b/app/Http/Controllers/KelasController.php
@@ -9,7 +9,7 @@ class KelasController extends Controller
 {
     public function index()
     {
-        $kelas = Kelas::all();
+        $kelas = Kelas::paginate(10)->withQueryString();
         return view('kelas.index', compact('kelas'));
     }
 

--- a/app/Http/Controllers/MapelController.php
+++ b/app/Http/Controllers/MapelController.php
@@ -9,8 +9,8 @@ class MapelController extends Controller
 {
     public function index()
     {
-        $mapel = MataPelajaran::all();
-        return view('mapel.index', compact('mapel'));
+        $mapel = MataPelajaran::paginate(10)->withQueryString();
+        return view('mapel.index', compact('mapel')); 
     }
 
     public function create()

--- a/app/Http/Controllers/NilaiController.php
+++ b/app/Http/Controllers/NilaiController.php
@@ -40,7 +40,7 @@ class NilaiController extends Controller
             });
         }
 
-        $nilai = $query->get();
+        $nilai = $query->paginate(10)->withQueryString();
 
         return view('nilai.index', compact('nilai', 'search'));
     }

--- a/app/Http/Controllers/PengajaranController.php
+++ b/app/Http/Controllers/PengajaranController.php
@@ -29,7 +29,7 @@ class PengajaranController extends Controller
             });
         }
 
-        $pengajaran = $query->get();
+        $pengajaran = $query->paginate(10)->withQueryString();
 
         return view('pengajaran.index', compact('pengajaran', 'search'));
     }

--- a/app/Http/Controllers/SiswaController.php
+++ b/app/Http/Controllers/SiswaController.php
@@ -23,7 +23,7 @@ class SiswaController extends Controller
             });
         }
 
-        $siswa = $query->get();
+        $siswa = $query->paginate(10)->withQueryString();
 
         return view('siswa.index', compact('siswa', 'search'));
     }

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -24,7 +24,7 @@ class UserController extends Controller
             });
         }
 
-        $users = $query->get();
+        $users = $query->paginate(10)->withQueryString();
 
         return view('users.index', compact('users', 'search'));
     }

--- a/resources/views/absensi/index.blade.php
+++ b/resources/views/absensi/index.blade.php
@@ -46,4 +46,5 @@
         @endforeach
     </tbody>
 </table>
+{{ $absensi->links() }}
 @endsection

--- a/resources/views/guru/index.blade.php
+++ b/resources/views/guru/index.blade.php
@@ -46,4 +46,5 @@
         @endforeach
     </tbody>
 </table>
+{{ $guru->links() }}
 @endsection

--- a/resources/views/kelas/index.blade.php
+++ b/resources/views/kelas/index.blade.php
@@ -34,4 +34,5 @@
         @endforeach
     </tbody>
 </table>
+{{ $kelas->links() }}
 @endsection

--- a/resources/views/mapel/index.blade.php
+++ b/resources/views/mapel/index.blade.php
@@ -34,4 +34,5 @@
         @endforeach
     </tbody>
 </table>
+{{ $mapel->links() }}
 @endsection

--- a/resources/views/nilai/index.blade.php
+++ b/resources/views/nilai/index.blade.php
@@ -42,4 +42,5 @@
         @endforeach
     </tbody>
 </table>
+{{ $nilai->links() }}
 @endsection

--- a/resources/views/pengajaran/index.blade.php
+++ b/resources/views/pengajaran/index.blade.php
@@ -42,4 +42,5 @@
         @endforeach
     </tbody>
 </table>
+{{ $pengajaran->links() }}
 @endsection

--- a/resources/views/siswa/index.blade.php
+++ b/resources/views/siswa/index.blade.php
@@ -50,4 +50,5 @@
         @endforeach
     </tbody>
 </table>
+{{ $siswa->links() }}
 @endsection

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -42,4 +42,5 @@
         @endforeach
     </tbody>
 </table>
+{{ $users->links() }}
 @endsection

--- a/tests/Feature/KelasCrudTest.php
+++ b/tests/Feature/KelasCrudTest.php
@@ -14,9 +14,14 @@ class KelasCrudTest extends TestCase
     {
         $user = User::factory()->create(['role' => 'admin']);
 
+        for ($i = 1; $i <= 11; $i++) {
+            \App\Models\Kelas::create(['nama' => 'K'.$i]);
+        }
+
         $response = $this->actingAs($user)->get('/kelas');
 
         $response->assertOk();
         $response->assertSee('Daftar Kelas');
+        $response->assertSee('?page=2');
     }
 }

--- a/tests/Feature/PaginationTest.php
+++ b/tests/Feature/PaginationTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Siswa;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PaginationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_siswa_index_displays_pagination_links(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+
+        for ($i = 1; $i <= 11; $i++) {
+            Siswa::create([
+                'nama' => 'Siswa '.$i,
+                'nisn' => str_pad((string)$i, 10, '0', STR_PAD_LEFT),
+                'kelas' => '10A',
+                'tempat_lahir' => 'Test',
+                'jenis_kelamin' => 'L',
+                'tanggal_lahir' => '2000-01-01',
+            ]);
+        }
+
+        $response = $this->actingAs($user)->get('/siswa');
+        $response->assertOk();
+        $response->assertSee('?page=2');
+    }
+}


### PR DESCRIPTION
## Summary
- paginate index queries across controllers
- show pagination links in index views
- keep search parameters on pagination
- add feature tests for pagination

## Testing
- `vendor/bin/phpunit --stop-on-failure` *(fails: SQLSTATE[HY000]: General error: 1 near "CHANGE": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_686a4cb317b0832b89ff7b9be861cab6