### PR TITLE
Implement unique homeroom teacher constraint

### DIFF
--- a/app/Http/Controllers/KelasController.php
+++ b/app/Http/Controllers/KelasController.php
@@ -24,7 +24,7 @@ class KelasController extends Controller
     {
         Kelas::create($request->validate([
             'nama' => 'required',
-            'guru_id' => 'required|exists:guru,id'
+            'guru_id' => 'required|exists:guru,id|unique:kelas,guru_id'
         ]));
 
         return redirect()->route('kelas.index')->with('success', 'Kelas berhasil ditambahkan');
@@ -40,7 +40,7 @@ class KelasController extends Controller
     {
         $kela->update($request->validate([
             'nama' => 'required',
-            'guru_id' => 'required|exists:guru,id'
+            'guru_id' => 'required|exists:guru,id|unique:kelas,guru_id,' . $kela->id
         ]));
 
         return redirect()->route('kelas.index')->with('success', 'Kelas berhasil diupdate');

--- a/database/migrations/2025_07_06_000002_add_unique_guru_id_to_kelas_table.php
+++ b/database/migrations/2025_07_06_000002_add_unique_guru_id_to_kelas_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('kelas', function (Blueprint $table) {
+            $table->unique('guru_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('kelas', function (Blueprint $table) {
+            $table->dropUnique('kelas_guru_id_unique');
+        });
+    }
+};

--- a/tests/Feature/JadwalConflictTest.php
+++ b/tests/Feature/JadwalConflictTest.php
@@ -25,8 +25,22 @@ class JadwalConflictTest extends TestCase
             'tanggal_lahir' => '1980-01-01',
         ]);
         $mapel = MataPelajaran::create(['nama' => 'Matematika']);
-        $kelasA = Kelas::create(['nama' => 'A']);
-        $kelasB = Kelas::create(['nama' => 'B']);
+        $waliA = Guru::create([
+            'nuptk' => '301',
+            'nama' => 'Wali A',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+        ]);
+        $waliB = Guru::create([
+            'nuptk' => '302',
+            'nama' => 'Wali B',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+        ]);
+        $kelasA = Kelas::create(['nama' => 'A', 'guru_id' => $waliA->id]);
+        $kelasB = Kelas::create(['nama' => 'B', 'guru_id' => $waliB->id]);
 
         $this->actingAs($user)->post('/jadwal', [
             'kelas_id' => $kelasA->id,
@@ -65,8 +79,22 @@ class JadwalConflictTest extends TestCase
             'tanggal_lahir' => '1985-01-01',
         ]);
         $mapel = MataPelajaran::create(['nama' => 'IPA']);
-        $kelasA = Kelas::create(['nama' => 'A']);
-        $kelasB = Kelas::create(['nama' => 'B']);
+        $waliA = Guru::create([
+            'nuptk' => '303',
+            'nama' => 'Wali C',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+        ]);
+        $waliB = Guru::create([
+            'nuptk' => '304',
+            'nama' => 'Wali D',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+        ]);
+        $kelasA = Kelas::create(['nama' => 'A', 'guru_id' => $waliA->id]);
+        $kelasB = Kelas::create(['nama' => 'B', 'guru_id' => $waliB->id]);
 
         $this->actingAs($user)->post('/jadwal', [
             'kelas_id' => $kelasA->id,

--- a/tests/Feature/JadwalPengajaranSyncTest.php
+++ b/tests/Feature/JadwalPengajaranSyncTest.php
@@ -25,7 +25,14 @@ class JadwalPengajaranSyncTest extends TestCase
             'tanggal_lahir' => '1980-01-01',
         ]);
         $mapel = MataPelajaran::create(['nama' => 'Matematika']);
-        $kelas = Kelas::create(['nama' => '10']);
+        $wali = Guru::create([
+            'nuptk' => '1234',
+            'nama' => 'Wali 10',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+        ]);
+        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id]);
 
         $response = $this->actingAs($user)->post('/jadwal', [
             'kelas_id' => $kelas->id,
@@ -62,7 +69,14 @@ class JadwalPengajaranSyncTest extends TestCase
             'tanggal_lahir' => '1985-01-01',
         ]);
         $mapel = MataPelajaran::create(['nama' => 'IPA']);
-        $kelas = Kelas::create(['nama' => '10']);
+        $wali = Guru::create([
+            'nuptk' => '1235',
+            'nama' => 'Wali 10B',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+        ]);
+        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id]);
 
         $this->actingAs($user)->post('/jadwal', [
             'kelas_id' => $kelas->id,

--- a/tests/Feature/JadwalPengajaranTeacherLockTest.php
+++ b/tests/Feature/JadwalPengajaranTeacherLockTest.php
@@ -33,7 +33,14 @@ class JadwalPengajaranTeacherLockTest extends TestCase
             'tanggal_lahir' => '1985-01-01',
         ]);
         $mapel = MataPelajaran::create(['nama' => 'Bahasa Indonesia']);
-        $kelas = Kelas::create(['nama' => '10']);
+        $wali = Guru::create([
+            'nuptk' => '5003',
+            'nama' => 'Wali 10',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+        ]);
+        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id]);
 
         $this->actingAs($user)->post('/jadwal', [
             'kelas_id' => $kelas->id,

--- a/tests/Feature/JadwalValidationTest.php
+++ b/tests/Feature/JadwalValidationTest.php
@@ -25,7 +25,14 @@ class JadwalValidationTest extends TestCase
             'tanggal_lahir' => '1990-01-01',
         ]);
         $mapel = MataPelajaran::create(['nama' => 'Matematika']);
-        $kelas = Kelas::create(['nama' => '10']);
+        $wali = Guru::create([
+            'nuptk' => '998',
+            'nama' => 'Wali 10',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+        ]);
+        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id]);
 
         $response = $this->actingAs($user)
             ->from('/jadwal/create')

--- a/tests/Feature/KelasCrudTest.php
+++ b/tests/Feature/KelasCrudTest.php
@@ -15,7 +15,14 @@ class KelasCrudTest extends TestCase
         $user = User::factory()->create(['role' => 'admin']);
 
         for ($i = 1; $i <= 11; $i++) {
-            \App\Models\Kelas::create(['nama' => 'K'.$i]);
+            $wali = \App\Models\Guru::create([
+                'nuptk' => '900'.$i,
+                'nama' => 'Wali '.$i,
+                'tempat_lahir' => 'Kota',
+                'jenis_kelamin' => 'L',
+                'tanggal_lahir' => '1990-01-01',
+            ]);
+            \App\Models\Kelas::create(['nama' => 'K'.$i, 'guru_id' => $wali->id]);
         }
 
         $response = $this->actingAs($user)->get('/kelas');

--- a/tests/Feature/PengajaranUniqueTest.php
+++ b/tests/Feature/PengajaranUniqueTest.php
@@ -32,7 +32,14 @@ class PengajaranUniqueTest extends TestCase
             'tanggal_lahir' => '1985-01-01',
         ]);
         $mapel = MataPelajaran::create(['nama' => 'Matematika']);
-        $kelas = Kelas::create(['nama' => '10']);
+        $wali = Guru::create([
+            'nuptk' => '1003',
+            'nama' => 'Wali 10',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+        ]);
+        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id]);
 
         $this->actingAs($user)->post('/pengajaran', [
             'guru_nama' => $guruA->nama,


### PR DESCRIPTION
## Summary
- restrict each teacher to be homeroom teacher for only one class
- add database migration and validation rules
- fix feature tests to create classes with assigned homeroom teachers

## Testing
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_686a59f3619c832bbe38cec7d9a75bfd