### PR TITLE
Add Tahun Ajaran management with tests

### DIFF
--- a/app/Http/Controllers/KelasController.php
+++ b/app/Http/Controllers/KelasController.php
@@ -4,27 +4,30 @@ namespace App\Http\Controllers;
 
 use App\Models\Kelas;
 use App\Models\Guru;
+use App\Models\TahunAjaran;
 use Illuminate\Http\Request;
 
 class KelasController extends Controller
 {
     public function index()
     {
-        $kelas = Kelas::with('waliKelas')->paginate(10)->withQueryString();
+        $kelas = Kelas::with(['waliKelas', 'tahunAjaran'])->paginate(10)->withQueryString();
         return view('kelas.index', compact('kelas'));
     }
 
     public function create()
     {
         $guru = Guru::all();
-        return view('kelas.create', compact('guru'));
+        $tahun_ajaran = TahunAjaran::all();
+        return view('kelas.create', compact('guru', 'tahun_ajaran'));
     }
 
     public function store(Request $request)
     {
         Kelas::create($request->validate([
             'nama' => 'required',
-            'guru_id' => 'required|exists:guru,id|unique:kelas,guru_id'
+            'guru_id' => 'required|exists:guru,id|unique:kelas,guru_id',
+            'tahun_ajaran_id' => 'required|exists:tahun_ajaran,id'
         ]));
 
         return redirect()->route('kelas.index')->with('success', 'Kelas berhasil ditambahkan');
@@ -33,14 +36,16 @@ class KelasController extends Controller
     public function edit(Kelas $kela)
     {
         $guru = Guru::all();
-        return view('kelas.edit', ['kela' => $kela, 'guru' => $guru]);
+        $tahun_ajaran = TahunAjaran::all();
+        return view('kelas.edit', ['kela' => $kela, 'guru' => $guru, 'tahun_ajaran' => $tahun_ajaran]);
     }
 
     public function update(Request $request, Kelas $kela)
     {
         $kela->update($request->validate([
             'nama' => 'required',
-            'guru_id' => 'required|exists:guru,id|unique:kelas,guru_id,' . $kela->id
+            'guru_id' => 'required|exists:guru,id|unique:kelas,guru_id,' . $kela->id,
+            'tahun_ajaran_id' => 'required|exists:tahun_ajaran,id'
         ]));
 
         return redirect()->route('kelas.index')->with('success', 'Kelas berhasil diupdate');

--- a/app/Http/Controllers/TahunAjaranController.php
+++ b/app/Http/Controllers/TahunAjaranController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\TahunAjaran;
+use Illuminate\Http\Request;
+
+class TahunAjaranController extends Controller
+{
+    public function index()
+    {
+        $tahun_ajaran = TahunAjaran::paginate(10)->withQueryString();
+        return view('tahun_ajaran.index', compact('tahun_ajaran'));
+    }
+
+    public function create()
+    {
+        return view('tahun_ajaran.create');
+    }
+
+    public function store(Request $request)
+    {
+        TahunAjaran::create($request->validate([
+            'nama' => 'required',
+            'start_date' => 'required|date',
+            'end_date' => 'required|date|after:start_date',
+        ]));
+
+        return redirect()->route('tahun-ajaran.index')->with('success', 'Tahun ajaran berhasil ditambahkan');
+    }
+
+    public function edit(TahunAjaran $tahun_ajaran)
+    {
+        return view('tahun_ajaran.edit', compact('tahun_ajaran'));
+    }
+
+    public function update(Request $request, TahunAjaran $tahun_ajaran)
+    {
+        $tahun_ajaran->update($request->validate([
+            'nama' => 'required',
+            'start_date' => 'required|date',
+            'end_date' => 'required|date|after:start_date',
+        ]));
+
+        return redirect()->route('tahun-ajaran.index')->with('success', 'Tahun ajaran berhasil diupdate');
+    }
+
+    public function destroy(TahunAjaran $tahun_ajaran)
+    {
+        $tahun_ajaran->delete();
+        return redirect()->route('tahun-ajaran.index')->with('success', 'Tahun ajaran berhasil dihapus');
+    }
+}

--- a/app/Models/Kelas.php
+++ b/app/Models/Kelas.php
@@ -5,16 +5,22 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Guru;
+use App\Models\TahunAjaran;
 
 class Kelas extends Model
 {
     use HasFactory;
 
     protected $table = 'kelas';
-    protected $fillable = ['nama', 'guru_id'];
+    protected $fillable = ['nama', 'guru_id', 'tahun_ajaran_id'];
 
     public function waliKelas()
     {
         return $this->belongsTo(Guru::class, 'guru_id');
+    }
+
+    public function tahunAjaran()
+    {
+        return $this->belongsTo(TahunAjaran::class, 'tahun_ajaran_id');
     }
 }

--- a/app/Models/TahunAjaran.php
+++ b/app/Models/TahunAjaran.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TahunAjaran extends Model
+{
+    use HasFactory;
+
+    protected $table = 'tahun_ajaran';
+
+    protected $fillable = ['nama', 'start_date', 'end_date'];
+}

--- a/database/migrations/2025_07_07_000000_create_tahun_ajaran_table.php
+++ b/database/migrations/2025_07_07_000000_create_tahun_ajaran_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('tahun_ajaran', function (Blueprint $table) {
+            $table->id();
+            $table->string('nama');
+            $table->date('start_date');
+            $table->date('end_date');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tahun_ajaran');
+    }
+};

--- a/database/migrations/2025_07_07_000001_add_tahun_ajaran_id_to_kelas_table.php
+++ b/database/migrations/2025_07_07_000001_add_tahun_ajaran_id_to_kelas_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('kelas', function (Blueprint $table) {
+            $table->foreignId('tahun_ajaran_id')->constrained('tahun_ajaran');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('kelas', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('tahun_ajaran_id');
+        });
+    }
+};

--- a/resources/views/kelas/create.blade.php
+++ b/resources/views/kelas/create.blade.php
@@ -30,6 +30,16 @@
         </select>
         <x-input-error :messages="$errors->get('guru_id')" class="mt-1" />
     </div>
+    <div class="mb-3">
+        <label>Tahun Ajaran</label>
+        <select name="tahun_ajaran_id" class="form-control" required>
+            <option value="">-- Pilih Tahun Ajaran --</option>
+            @foreach($tahun_ajaran as $ta)
+                <option value="{{ $ta->id }}">{{ $ta->nama }}</option>
+            @endforeach
+        </select>
+        <x-input-error :messages="$errors->get('tahun_ajaran_id')" class="mt-1" />
+    </div>
     <button class="btn btn-success">Simpan</button>
     <a href="{{ route('kelas.index') }}" class="btn btn-secondary">Batal</a>
 </form>

--- a/resources/views/kelas/edit.blade.php
+++ b/resources/views/kelas/edit.blade.php
@@ -30,6 +30,16 @@
         </select>
         <x-input-error :messages="$errors->get('guru_id')" class="mt-1" />
     </div>
+    <div class="mb-3">
+        <label>Tahun Ajaran</label>
+        <select name="tahun_ajaran_id" class="form-control" required>
+            <option value="">-- Pilih Tahun Ajaran --</option>
+            @foreach($tahun_ajaran as $ta)
+                <option value="{{ $ta->id }}" {{ $kela->tahun_ajaran_id == $ta->id ? 'selected' : '' }}>{{ $ta->nama }}</option>
+            @endforeach
+        </select>
+        <x-input-error :messages="$errors->get('tahun_ajaran_id')" class="mt-1" />
+    </div>
     <button class="btn btn-primary">Update</button>
     <a href="{{ route('kelas.index') }}" class="btn btn-secondary">Batal</a>
 </form>

--- a/resources/views/kelas/index.blade.php
+++ b/resources/views/kelas/index.blade.php
@@ -15,6 +15,7 @@
         <tr>
             <th>ID</th>
             <th>Nama Kelas</th>
+            <th>Tahun Ajaran</th>
             <th>Wali Kelas</th>
             <th>Aksi</th>
         </tr>
@@ -24,6 +25,7 @@
         <tr>
             <td>{{ $k->id }}</td>
             <td>{{ $k->nama }}</td>
+            <td>{{ $k->tahunAjaran->nama ?? '' }}</td>
             <td>{{ $k->waliKelas->nama ?? '' }}</td>
             <td>
                 <a href="{{ route('kelas.edit', $k->id) }}" class="btn btn-sm btn-warning">Edit</a>

--- a/resources/views/tahun_ajaran/create.blade.php
+++ b/resources/views/tahun_ajaran/create.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.app')
+
+@section('title', 'Tambah Tahun Ajaran')
+
+@section('content')
+<h1>Tambah Tahun Ajaran</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+<form action="{{ route('tahun-ajaran.store') }}" method="POST">
+    @csrf
+    <div class="mb-3">
+        <label>Nama</label>
+        <input type="text" name="nama" class="form-control" required>
+        <x-input-error :messages="$errors->get('nama')" class="mt-1" />
+    </div>
+    <div class="mb-3">
+        <label>Start Date</label>
+        <input type="date" name="start_date" class="form-control" required>
+        <x-input-error :messages="$errors->get('start_date')" class="mt-1" />
+    </div>
+    <div class="mb-3">
+        <label>End Date</label>
+        <input type="date" name="end_date" class="form-control" required>
+        <x-input-error :messages="$errors->get('end_date')" class="mt-1" />
+    </div>
+    <button class="btn btn-success">Simpan</button>
+    <a href="{{ route('tahun-ajaran.index') }}" class="btn btn-secondary">Batal</a>
+</form>
+@endsection

--- a/resources/views/tahun_ajaran/edit.blade.php
+++ b/resources/views/tahun_ajaran/edit.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.app')
+
+@section('title', 'Edit Tahun Ajaran')
+
+@section('content')
+<h1>Edit Tahun Ajaran</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+<form action="{{ route('tahun-ajaran.update', $tahun_ajaran->id) }}" method="POST">
+    @csrf @method('PUT')
+    <div class="mb-3">
+        <label>Nama</label>
+        <input type="text" name="nama" class="form-control" value="{{ $tahun_ajaran->nama }}" required>
+        <x-input-error :messages="$errors->get('nama')" class="mt-1" />
+    </div>
+    <div class="mb-3">
+        <label>Start Date</label>
+        <input type="date" name="start_date" class="form-control" value="{{ $tahun_ajaran->start_date }}" required>
+        <x-input-error :messages="$errors->get('start_date')" class="mt-1" />
+    </div>
+    <div class="mb-3">
+        <label>End Date</label>
+        <input type="date" name="end_date" class="form-control" value="{{ $tahun_ajaran->end_date }}" required>
+        <x-input-error :messages="$errors->get('end_date')" class="mt-1" />
+    </div>
+    <button class="btn btn-primary">Update</button>
+    <a href="{{ route('tahun-ajaran.index') }}" class="btn btn-secondary">Batal</a>
+</form>
+@endsection

--- a/resources/views/tahun_ajaran/index.blade.php
+++ b/resources/views/tahun_ajaran/index.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.app')
+
+@section('title', 'Daftar Tahun Ajaran')
+
+@section('content')
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1>Daftar Tahun Ajaran</h1>
+    <a href="{{ route('tahun-ajaran.create') }}" class="btn btn-primary">+ Tambah Tahun Ajaran</a>
+</div>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>ID</th>
+            <th>Nama</th>
+            <th>Mulai</th>
+            <th>Selesai</th>
+            <th>Aksi</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach ($tahun_ajaran as $ta)
+        <tr>
+            <td>{{ $ta->id }}</td>
+            <td>{{ $ta->nama }}</td>
+            <td>{{ $ta->start_date }}</td>
+            <td>{{ $ta->end_date }}</td>
+            <td>
+                <a href="{{ route('tahun-ajaran.edit', $ta->id) }}" class="btn btn-sm btn-warning">Edit</a>
+                <form action="{{ route('tahun-ajaran.destroy', $ta->id) }}" method="POST" class="d-inline" onsubmit="return confirm('Yakin hapus?')">
+                    @csrf @method('DELETE')
+                    <button class="btn btn-sm btn-danger">Hapus</button>
+                </form>
+            </td>
+        </tr>
+        @endforeach
+    </tbody>
+</table>
+{{ $tahun_ajaran->links('pagination::bootstrap-5') }}
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\GuruController;
 use App\Http\Controllers\SiswaController;
 use App\Http\Controllers\MapelController;
 use App\Http\Controllers\KelasController;
+use App\Http\Controllers\TahunAjaranController;
 use App\Http\Controllers\NilaiController;
 use App\Http\Controllers\AbsensiController;
 use App\Http\Controllers\RaporController;
@@ -31,6 +32,7 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::resource('guru', GuruController::class)->except('show');
     Route::resource('siswa', SiswaController::class)->except('show');
     Route::resource('mapel', MapelController::class)->except('show');
+    Route::resource('tahun-ajaran', TahunAjaranController::class)->except('show');
     Route::resource('kelas', KelasController::class)->except('show');
     Route::resource('users', UserController::class)->except('show');
     Route::resource('pengajaran', PengajaranController::class)->except('show');

--- a/tests/Feature/JadwalConflictTest.php
+++ b/tests/Feature/JadwalConflictTest.php
@@ -39,8 +39,13 @@ class JadwalConflictTest extends TestCase
             'jenis_kelamin' => 'L',
             'tanggal_lahir' => '1990-01-01',
         ]);
-        $kelasA = Kelas::create(['nama' => 'A', 'guru_id' => $waliA->id]);
-        $kelasB = Kelas::create(['nama' => 'B', 'guru_id' => $waliB->id]);
+        $ta = \App\Models\TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelasA = Kelas::create(['nama' => 'A', 'guru_id' => $waliA->id, 'tahun_ajaran_id' => $ta->id]);
+        $kelasB = Kelas::create(['nama' => 'B', 'guru_id' => $waliB->id, 'tahun_ajaran_id' => $ta->id]);
 
         $this->actingAs($user)->post('/jadwal', [
             'kelas_id' => $kelasA->id,
@@ -93,8 +98,13 @@ class JadwalConflictTest extends TestCase
             'jenis_kelamin' => 'L',
             'tanggal_lahir' => '1990-01-01',
         ]);
-        $kelasA = Kelas::create(['nama' => 'A', 'guru_id' => $waliA->id]);
-        $kelasB = Kelas::create(['nama' => 'B', 'guru_id' => $waliB->id]);
+        $ta = \App\Models\TahunAjaran::create([
+            'nama' => '2025/2026',
+            'start_date' => '2025-07-01',
+            'end_date' => '2026-06-30',
+        ]);
+        $kelasA = Kelas::create(['nama' => 'A', 'guru_id' => $waliA->id, 'tahun_ajaran_id' => $ta->id]);
+        $kelasB = Kelas::create(['nama' => 'B', 'guru_id' => $waliB->id, 'tahun_ajaran_id' => $ta->id]);
 
         $this->actingAs($user)->post('/jadwal', [
             'kelas_id' => $kelasA->id,

--- a/tests/Feature/JadwalPengajaranSyncTest.php
+++ b/tests/Feature/JadwalPengajaranSyncTest.php
@@ -32,7 +32,12 @@ class JadwalPengajaranSyncTest extends TestCase
             'jenis_kelamin' => 'L',
             'tanggal_lahir' => '1990-01-01',
         ]);
-        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id]);
+        $ta = \App\Models\TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id, 'tahun_ajaran_id' => $ta->id]);
 
         $response = $this->actingAs($user)->post('/jadwal', [
             'kelas_id' => $kelas->id,
@@ -76,7 +81,12 @@ class JadwalPengajaranSyncTest extends TestCase
             'jenis_kelamin' => 'L',
             'tanggal_lahir' => '1990-01-01',
         ]);
-        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id]);
+        $ta = \App\Models\TahunAjaran::create([
+            'nama' => '2025/2026',
+            'start_date' => '2025-07-01',
+            'end_date' => '2026-06-30',
+        ]);
+        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id, 'tahun_ajaran_id' => $ta->id]);
 
         $this->actingAs($user)->post('/jadwal', [
             'kelas_id' => $kelas->id,

--- a/tests/Feature/JadwalPengajaranTeacherLockTest.php
+++ b/tests/Feature/JadwalPengajaranTeacherLockTest.php
@@ -40,7 +40,12 @@ class JadwalPengajaranTeacherLockTest extends TestCase
             'jenis_kelamin' => 'L',
             'tanggal_lahir' => '1990-01-01',
         ]);
-        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id]);
+        $ta = \App\Models\TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id, 'tahun_ajaran_id' => $ta->id]);
 
         $this->actingAs($user)->post('/jadwal', [
             'kelas_id' => $kelas->id,

--- a/tests/Feature/JadwalValidationTest.php
+++ b/tests/Feature/JadwalValidationTest.php
@@ -32,7 +32,12 @@ class JadwalValidationTest extends TestCase
             'jenis_kelamin' => 'L',
             'tanggal_lahir' => '1990-01-01',
         ]);
-        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id]);
+        $ta = \App\Models\TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id, 'tahun_ajaran_id' => $ta->id]);
 
         $response = $this->actingAs($user)
             ->from('/jadwal/create')

--- a/tests/Feature/KelasCrudTest.php
+++ b/tests/Feature/KelasCrudTest.php
@@ -14,6 +14,12 @@ class KelasCrudTest extends TestCase
     {
         $user = User::factory()->create(['role' => 'admin']);
 
+        $ta = \App\Models\TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+
         for ($i = 1; $i <= 11; $i++) {
             $wali = \App\Models\Guru::create([
                 'nuptk' => '900'.$i,
@@ -22,7 +28,7 @@ class KelasCrudTest extends TestCase
                 'jenis_kelamin' => 'L',
                 'tanggal_lahir' => '1990-01-01',
             ]);
-            \App\Models\Kelas::create(['nama' => 'K'.$i, 'guru_id' => $wali->id]);
+            \App\Models\Kelas::create(['nama' => 'K'.$i, 'guru_id' => $wali->id, 'tahun_ajaran_id' => $ta->id]);
         }
 
         $response = $this->actingAs($user)->get('/kelas');

--- a/tests/Feature/KelasTahunAjaranValidationTest.php
+++ b/tests/Feature/KelasTahunAjaranValidationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\Kelas;
+use App\Models\TahunAjaran;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class KelasTahunAjaranValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_tahun_ajaran_id_is_required_and_must_exist(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+        $guru = Guru::create([
+            'nuptk' => '7001',
+            'nama' => 'Wali',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+        ]);
+
+        $response = $this->actingAs($user)
+            ->from('/kelas/create')
+            ->post('/kelas', [
+                'nama' => '10',
+                'guru_id' => $guru->id,
+                'tahun_ajaran_id' => 999,
+            ]);
+        $response->assertRedirect('/kelas/create');
+        $response->assertSessionHasErrors('tahun_ajaran_id');
+        $this->assertEquals(0, Kelas::count());
+
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+
+        $response = $this->actingAs($user)
+            ->post('/kelas', [
+                'nama' => '10',
+                'guru_id' => $guru->id,
+                'tahun_ajaran_id' => $ta->id,
+            ]);
+        $response->assertRedirect('/kelas');
+        $this->assertEquals(1, Kelas::count());
+    }
+}

--- a/tests/Feature/PengajaranUniqueTest.php
+++ b/tests/Feature/PengajaranUniqueTest.php
@@ -39,7 +39,12 @@ class PengajaranUniqueTest extends TestCase
             'jenis_kelamin' => 'L',
             'tanggal_lahir' => '1990-01-01',
         ]);
-        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id]);
+        $ta = \App\Models\TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id, 'tahun_ajaran_id' => $ta->id]);
 
         $this->actingAs($user)->post('/pengajaran', [
             'guru_nama' => $guruA->nama,

--- a/tests/Feature/TahunAjaranCrudTest.php
+++ b/tests/Feature/TahunAjaranCrudTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\TahunAjaran;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TahunAjaranCrudTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_create_edit_and_delete_tahun_ajaran(): void
+    {
+        $user = User::factory()->create(['role' => 'admin']);
+
+        $response = $this->actingAs($user)->post('/tahun-ajaran', [
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $response->assertRedirect('/tahun-ajaran');
+        $ta = TahunAjaran::first();
+        $this->assertNotNull($ta);
+
+        $response = $this->actingAs($user)->put('/tahun-ajaran/'.$ta->id, [
+            'nama' => '2025/2026',
+            'start_date' => '2025-07-01',
+            'end_date' => '2026-06-30',
+        ]);
+        $response->assertRedirect('/tahun-ajaran');
+        $this->assertEquals('2025/2026', $ta->fresh()->nama);
+
+        $response = $this->actingAs($user)->delete('/tahun-ajaran/'.$ta->id);
+        $response->assertRedirect('/tahun-ajaran');
+        $this->assertEquals(0, TahunAjaran::count());
+    }
+}


### PR DESCRIPTION
## Summary
- create `tahun_ajaran` table and relation to `kelas`
- add `TahunAjaran` model and CRUD controller
- update `Kelas` model/controller/views to select academic year
- register admin routes for academic years
- implement feature tests for academic year CRUD and kelas validation
- update existing tests for new foreign key

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686a65469590832ba8d42e183ad08fa1