### PR TITLE
Convert class names to Roman numerals

### DIFF
--- a/database/seeders/KelasSeeder.php
+++ b/database/seeders/KelasSeeder.php
@@ -12,11 +12,11 @@ class KelasSeeder extends Seeder
         // Only create the base classes without A/B/C subdivisions
         $taId = DB::table('tahun_ajaran')->value('id');
         $data = [
-            ['nama' => '10', 'guru_id' => 1, 'tahun_ajaran_id' => $taId],
-            ['nama' => '11 IPA', 'guru_id' => 2, 'tahun_ajaran_id' => $taId],
-            ['nama' => '11 IPS', 'guru_id' => 3, 'tahun_ajaran_id' => $taId],
-            ['nama' => '12 IPA', 'guru_id' => 4, 'tahun_ajaran_id' => $taId],
-            ['nama' => '12 IPS', 'guru_id' => 5, 'tahun_ajaran_id' => $taId],
+            ['nama' => 'X', 'guru_id' => 1, 'tahun_ajaran_id' => $taId],
+            ['nama' => 'XI IPA', 'guru_id' => 2, 'tahun_ajaran_id' => $taId],
+            ['nama' => 'XI IPS', 'guru_id' => 3, 'tahun_ajaran_id' => $taId],
+            ['nama' => 'XII IPA', 'guru_id' => 4, 'tahun_ajaran_id' => $taId],
+            ['nama' => 'XII IPS', 'guru_id' => 5, 'tahun_ajaran_id' => $taId],
         ];
 
         DB::table('kelas')->insert($data);

--- a/database/seeders/PengajaranSeeder.php
+++ b/database/seeders/PengajaranSeeder.php
@@ -11,9 +11,9 @@ class PengajaranSeeder extends Seeder
     {
         $data = [];
         $kelasList = [
-            '10',
-            '11 IPA', '11 IPS',
-            '12 IPA', '12 IPS',
+            'X',
+            'XI IPA', 'XI IPS',
+            'XII IPA', 'XII IPS',
         ];
         $index = 0;
         for ($mapel = 1; $mapel <= 10; $mapel++) {

--- a/database/seeders/SiswaSeeder.php
+++ b/database/seeders/SiswaSeeder.php
@@ -15,9 +15,9 @@ class SiswaSeeder extends Seeder
         $data = [];
         $siswaUser = User::where('email', 'siswa@demo.com')->first();
         $kelasList = [
-            '10',
-            '11 IPA', '11 IPS',
-            '12 IPA', '12 IPS',
+            'X',
+            'XI IPA', 'XI IPS',
+            'XII IPA', 'XII IPS',
         ];
 
         for ($i = 1; $i <= 50; $i++) {

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -18,7 +18,7 @@ class DashboardTest extends TestCase
         Siswa::create([
             'nama' => 'Test1',
             'nisn' => '0000000001',
-            'kelas' => '10',
+            'kelas' => 'X',
             'tempat_lahir' => 'Bandung',
             'jenis_kelamin' => 'L',
             'tanggal_lahir' => '2000-01-01'
@@ -26,7 +26,7 @@ class DashboardTest extends TestCase
         Siswa::create([
             'nama' => 'Test2',
             'nisn' => '0000000002',
-            'kelas' => '11 IPA',
+            'kelas' => 'XI IPA',
             'tempat_lahir' => 'Jakarta',
             'jenis_kelamin' => 'P',
             'tanggal_lahir' => '2000-01-02'

--- a/tests/Feature/JadwalPengajaranSyncTest.php
+++ b/tests/Feature/JadwalPengajaranSyncTest.php
@@ -37,7 +37,7 @@ class JadwalPengajaranSyncTest extends TestCase
             'start_date' => '2024-07-01',
             'end_date' => '2025-06-30',
         ]);
-        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id, 'tahun_ajaran_id' => $ta->id]);
+        $kelas = Kelas::create(['nama' => 'X', 'guru_id' => $wali->id, 'tahun_ajaran_id' => $ta->id]);
 
         $response = $this->actingAs($user)->post('/jadwal', [
             'kelas_id' => $kelas->id,
@@ -86,7 +86,7 @@ class JadwalPengajaranSyncTest extends TestCase
             'start_date' => '2025-07-01',
             'end_date' => '2026-06-30',
         ]);
-        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id, 'tahun_ajaran_id' => $ta->id]);
+        $kelas = Kelas::create(['nama' => 'X', 'guru_id' => $wali->id, 'tahun_ajaran_id' => $ta->id]);
 
         $this->actingAs($user)->post('/jadwal', [
             'kelas_id' => $kelas->id,

--- a/tests/Feature/JadwalPengajaranTeacherLockTest.php
+++ b/tests/Feature/JadwalPengajaranTeacherLockTest.php
@@ -45,7 +45,7 @@ class JadwalPengajaranTeacherLockTest extends TestCase
             'start_date' => '2024-07-01',
             'end_date' => '2025-06-30',
         ]);
-        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id, 'tahun_ajaran_id' => $ta->id]);
+        $kelas = Kelas::create(['nama' => 'X', 'guru_id' => $wali->id, 'tahun_ajaran_id' => $ta->id]);
 
         $this->actingAs($user)->post('/jadwal', [
             'kelas_id' => $kelas->id,

--- a/tests/Feature/JadwalValidationTest.php
+++ b/tests/Feature/JadwalValidationTest.php
@@ -37,7 +37,7 @@ class JadwalValidationTest extends TestCase
             'start_date' => '2024-07-01',
             'end_date' => '2025-06-30',
         ]);
-        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id, 'tahun_ajaran_id' => $ta->id]);
+        $kelas = Kelas::create(['nama' => 'X', 'guru_id' => $wali->id, 'tahun_ajaran_id' => $ta->id]);
 
         $response = $this->actingAs($user)
             ->from('/jadwal/create')

--- a/tests/Feature/KelasTahunAjaranValidationTest.php
+++ b/tests/Feature/KelasTahunAjaranValidationTest.php
@@ -27,7 +27,7 @@ class KelasTahunAjaranValidationTest extends TestCase
         $response = $this->actingAs($user)
             ->from('/kelas/create')
             ->post('/kelas', [
-                'nama' => '10',
+                'nama' => 'X',
                 'guru_id' => $guru->id,
                 'tahun_ajaran_id' => 999,
             ]);
@@ -43,7 +43,7 @@ class KelasTahunAjaranValidationTest extends TestCase
 
         $response = $this->actingAs($user)
             ->post('/kelas', [
-                'nama' => '10',
+                'nama' => 'X',
                 'guru_id' => $guru->id,
                 'tahun_ajaran_id' => $ta->id,
             ]);

--- a/tests/Feature/NilaiSemesterTest.php
+++ b/tests/Feature/NilaiSemesterTest.php
@@ -16,7 +16,7 @@ class NilaiSemesterTest extends TestCase
         $siswa = Siswa::create([
             'nama' => 'Siswa Test',
             'nisn' => '0000000001',
-            'kelas' => '10',
+            'kelas' => 'X',
             'tempat_lahir' => 'Bandung',
             'jenis_kelamin' => 'L',
             'tanggal_lahir' => '2000-01-01',

--- a/tests/Feature/PaginationTest.php
+++ b/tests/Feature/PaginationTest.php
@@ -19,7 +19,7 @@ class PaginationTest extends TestCase
             Siswa::create([
                 'nama' => 'Siswa '.$i,
                 'nisn' => str_pad((string)$i, 10, '0', STR_PAD_LEFT),
-                'kelas' => '10',
+                'kelas' => 'X',
                 'tempat_lahir' => 'Test',
                 'jenis_kelamin' => 'L',
                 'tanggal_lahir' => '2000-01-01',

--- a/tests/Feature/PengajaranUniqueTest.php
+++ b/tests/Feature/PengajaranUniqueTest.php
@@ -44,7 +44,7 @@ class PengajaranUniqueTest extends TestCase
             'start_date' => '2024-07-01',
             'end_date' => '2025-06-30',
         ]);
-        $kelas = Kelas::create(['nama' => '10', 'guru_id' => $wali->id, 'tahun_ajaran_id' => $ta->id]);
+        $kelas = Kelas::create(['nama' => 'X', 'guru_id' => $wali->id, 'tahun_ajaran_id' => $ta->id]);
 
         $this->actingAs($user)->post('/pengajaran', [
             'guru_nama' => $guruA->nama,


### PR DESCRIPTION
## Summary
- change default class names in seeders from numeric levels to Roman numerals
- update tests to match new class names

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_686a72af72b8832b902431cf4b14c0c6