### PR TITLE
Implement per-subject attendance flow

### DIFF
--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Siswa;
 use App\Models\Nilai;
 use App\Models\Absensi;
+use App\Models\MataPelajaran;
 use Illuminate\Support\Facades\Auth;
 use PDF;
 use Illuminate\Http\Request;
@@ -26,7 +27,7 @@ class StudentController extends Controller
     public function absensi()
     {
         $siswa = Siswa::where('user_id', Auth::id())->firstOrFail();
-        $absensi = $siswa->absensi()->get();
+        $absensi = $siswa->absensi()->with('mapel')->get();
         return view('siswa.absensi', compact('siswa', 'absensi'));
     }
 
@@ -35,7 +36,8 @@ class StudentController extends Controller
      */
     public function absenForm()
     {
-        return view('siswa.absen');
+        $mapel = MataPelajaran::all();
+        return view('siswa.absen', compact('mapel'));
     }
 
     /**
@@ -45,11 +47,12 @@ class StudentController extends Controller
     {
         $siswa = Siswa::where('user_id', Auth::id())->firstOrFail();
         $data = $request->validate([
+            'mapel_id' => 'required|exists:mata_pelajaran,id',
             'status' => 'required|in:Hadir,Izin,Sakit,Alpha',
         ]);
 
         Absensi::updateOrCreate(
-            ['siswa_id' => $siswa->id, 'tanggal' => date('Y-m-d')],
+            ['siswa_id' => $siswa->id, 'mapel_id' => $data['mapel_id'], 'tanggal' => date('Y-m-d')],
             ['status' => $data['status']]
         );
 

--- a/app/Models/Absensi.php
+++ b/app/Models/Absensi.php
@@ -4,16 +4,22 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Models\MataPelajaran;
 
 class Absensi extends Model
 {
     use HasFactory;
 
     protected $table = 'absensi';
-    protected $fillable = ['siswa_id', 'tanggal', 'status'];
+    protected $fillable = ['siswa_id', 'mapel_id', 'tanggal', 'status'];
 
     public function siswa()
     {
         return $this->belongsTo(Siswa::class);
+    }
+
+    public function mapel()
+    {
+        return $this->belongsTo(MataPelajaran::class, 'mapel_id');
     }
 }

--- a/database/migrations/2025_07_07_000002_add_mapel_id_to_absensi_table.php
+++ b/database/migrations/2025_07_07_000002_add_mapel_id_to_absensi_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('absensi', function (Blueprint $table) {
+            $table->foreignId('mapel_id')->nullable()->after('siswa_id')->constrained('mata_pelajaran');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('absensi', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('mapel_id');
+        });
+    }
+};

--- a/database/seeders/AbsensiSeeder.php
+++ b/database/seeders/AbsensiSeeder.php
@@ -15,6 +15,7 @@ class AbsensiSeeder extends Seeder
             for ($d = 1; $d <= 5; $d++) {
                 $data[] = [
                     'siswa_id' => $s,
+                    'mapel_id' => rand(1, 5),
                     'tanggal' => date('Y-m-d', strtotime("2025-07-" . str_pad($d, 2, '0', STR_PAD_LEFT))),
                     'status' => $statuses[array_rand($statuses)],
                 ];

--- a/resources/views/absensi/create.blade.php
+++ b/resources/views/absensi/create.blade.php
@@ -26,6 +26,16 @@
         <x-input-error :messages="$errors->get('siswa_id')" class="mt-1" />
     </div>
     <div class="mb-3">
+        <label>Mata Pelajaran</label>
+        <select name="mapel_id" class="form-control" required>
+            <option value="">-- Pilih Mapel --</option>
+            @foreach ($mapel as $m)
+                <option value="{{ $m->id }}">{{ $m->nama }}</option>
+            @endforeach
+        </select>
+        <x-input-error :messages="$errors->get('mapel_id')" class="mt-1" />
+    </div>
+    <div class="mb-3">
         <label>Tanggal</label>
         <input type="date" name="tanggal" class="form-control" required>
         <x-input-error :messages="$errors->get('tanggal')" class="mt-1" />

--- a/resources/views/absensi/edit.blade.php
+++ b/resources/views/absensi/edit.blade.php
@@ -26,6 +26,16 @@
         <x-input-error :messages="$errors->get('siswa_id')" class="mt-1" />
     </div>
     <div class="mb-3">
+        <label>Mata Pelajaran</label>
+        <select name="mapel_id" class="form-control" required>
+            <option value="">-- Pilih Mapel --</option>
+            @foreach ($mapel as $m)
+                <option value="{{ $m->id }}" @if($absensi->mapel_id == $m->id) selected @endif>{{ $m->nama }}</option>
+            @endforeach
+        </select>
+        <x-input-error :messages="$errors->get('mapel_id')" class="mt-1" />
+    </div>
+    <div class="mb-3">
         <label>Tanggal</label>
         <input type="date" name="tanggal" class="form-control" value="{{ $absensi->tanggal }}" required>
         <x-input-error :messages="$errors->get('tanggal')" class="mt-1" />

--- a/resources/views/absensi/index.blade.php
+++ b/resources/views/absensi/index.blade.php
@@ -8,6 +8,7 @@
     <div>
         <a href="{{ route('absensi.rekap') }}" class="btn btn-secondary me-2">Rekap Bulanan</a>
         <a href="{{ route('absensi.harian') }}" class="btn btn-success me-2">Input Harian</a>
+        <a href="{{ route('absensi.pelajaran') }}" class="btn btn-info me-2">Input Per Mapel</a>
         <a href="{{ route('absensi.create') }}" class="btn btn-primary">+ Tambah Absensi</a>
     </div>
 </div>

--- a/resources/views/absensi/pelajaran.blade.php
+++ b/resources/views/absensi/pelajaran.blade.php
@@ -1,0 +1,17 @@
+@extends('layouts.app')
+
+@section('title', 'Jadwal Hari Ini')
+
+@section('content')
+<h1 class="mb-3">Jadwal Hari {{ $hari }}</h1>
+<ul class="list-group">
+    @forelse($jadwal as $j)
+        <li class="list-group-item d-flex justify-content-between align-items-center">
+            <span>{{ $j->kelas->nama }} - {{ $j->mapel->nama }} ({{ $j->jam_mulai }} - {{ $j->jam_selesai }})</span>
+            <a href="{{ route('absensi.pelajaran.form', $j->id) }}" class="btn btn-sm btn-primary">Isi Absen</a>
+        </li>
+    @empty
+        <li class="list-group-item text-center">Tidak ada jadwal hari ini</li>
+    @endforelse
+</ul>
+@endsection

--- a/resources/views/absensi/pelajaran_form.blade.php
+++ b/resources/views/absensi/pelajaran_form.blade.php
@@ -1,0 +1,52 @@
+@extends('layouts.app')
+
+@section('title', 'Absensi ' . $jadwal->mapel->nama)
+
+@section('content')
+<h1 class="mb-3">Absensi {{ $jadwal->mapel->nama }} - {{ $jadwal->kelas->nama }}</h1>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+<form method="GET" class="row g-2 mb-3">
+    <div class="col-auto">
+        <input type="date" name="tanggal" value="{{ $tanggal }}" class="form-control" onchange="this.form.submit()">
+    </div>
+    <noscript class="col-auto"><button class="btn btn-primary">Tampilkan</button></noscript>
+</form>
+<form action="{{ route('absensi.pelajaran.store', $jadwal->id) }}" method="POST">
+    @csrf
+    <input type="hidden" name="tanggal" value="{{ $tanggal }}">
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>Nama</th>
+                <th>Hadir</th>
+                <th>Izin</th>
+                <th>Sakit</th>
+                <th>Alpha</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($siswa as $s)
+            <tr>
+                <td>{{ $s->nama }}</td>
+                <td><input type="radio" name="status[{{ $s->id }}]" value="Hadir" @checked(($absen[$s->id] ?? '')=='Hadir')></td>
+                <td><input type="radio" name="status[{{ $s->id }}]" value="Izin" @checked(($absen[$s->id] ?? '')=='Izin')></td>
+                <td><input type="radio" name="status[{{ $s->id }}]" value="Sakit" @checked(($absen[$s->id] ?? '')=='Sakit')></td>
+                <td><input type="radio" name="status[{{ $s->id }}]" value="Alpha" @checked(($absen[$s->id] ?? '')=='Alpha')></td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+    <button class="btn btn-success">Simpan</button>
+</form>
+@endsection

--- a/resources/views/siswa/absen.blade.php
+++ b/resources/views/siswa/absen.blade.php
@@ -19,6 +19,16 @@
 <form action="{{ route('student.absen') }}" method="POST">
     @csrf
     <div class="mb-3">
+        <label>Mata Pelajaran</label>
+        <select name="mapel_id" class="form-control" required>
+            <option value="">-- Pilih Mapel --</option>
+            @foreach($mapel as $m)
+                <option value="{{ $m->id }}">{{ $m->nama }}</option>
+            @endforeach
+        </select>
+        <x-input-error :messages="$errors->get('mapel_id')" class="mt-1" />
+    </div>
+    <div class="mb-3">
         <label>Status</label>
         <select name="status" class="form-control" required>
             <option value="">-- Pilih Status --</option>

--- a/resources/views/siswa/absensi.blade.php
+++ b/resources/views/siswa/absensi.blade.php
@@ -7,6 +7,7 @@
 <table class="table table-bordered">
     <thead>
         <tr>
+            <th>Mapel</th>
             <th>Tanggal</th>
             <th>Status</th>
         </tr>
@@ -14,6 +15,7 @@
     <tbody>
         @foreach($absensi as $a)
         <tr>
+            <td>{{ $a->mapel->nama ?? '-' }}</td>
             <td>{{ $a->tanggal }}</td>
             <td>{{ $a->status }}</td>
         </tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,6 +48,9 @@ Route::middleware(['auth', 'role:admin,guru'])->group(function () {
     Route::resource('penilaian', PenilaianController::class)->only('index','create','store','destroy');
     Route::get('/absensi/harian', [AbsensiController::class, 'harian'])->name('absensi.harian');
     Route::post('/absensi/harian', [AbsensiController::class, 'harianStore'])->name('absensi.harian.store');
+    Route::get('/absensi/pelajaran', [AbsensiController::class, 'pelajaran'])->name('absensi.pelajaran');
+    Route::get('/absensi/pelajaran/{jadwal}', [AbsensiController::class, 'pelajaranForm'])->name('absensi.pelajaran.form');
+    Route::post('/absensi/pelajaran/{jadwal}', [AbsensiController::class, 'pelajaranStore'])->name('absensi.pelajaran.store');
     Route::get('/absensi/rekap', [AbsensiController::class, 'rekap'])->name('absensi.rekap');
     Route::get('/absensi/rekap/export', [AbsensiController::class, 'exportRekap'])->name('absensi.rekap.export');
     Route::get('/rapor/{siswa}', [RaporController::class, 'cetak'])->name('rapor.cetak');


### PR DESCRIPTION
## Summary
- allow recording attendance per subject
- list today's classes for teachers
- update student attendance pages with subject selector
- seeders and migrations adjusted for new `mapel_id` field

## Testing
- `vendor/bin/phpunit --version` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686a91616334832ba68f80728680141f