### PR TITLE
Remove admin access to manual absensi entry

### DIFF
--- a/resources/views/absensi/index.blade.php
+++ b/resources/views/absensi/index.blade.php
@@ -7,8 +7,10 @@
     <h1>Daftar Absensi</h1>
     <div>
         <a href="{{ route('absensi.rekap') }}" class="btn btn-secondary me-2">Rekap Bulanan</a>
-        <a href="{{ route('absensi.pelajaran') }}" class="btn btn-info me-2">Input Per Mapel</a>
-        <a href="{{ route('absensi.create') }}" class="btn btn-primary">+ Tambah Absensi</a>
+        @if(Auth::user()->role === 'guru')
+            <a href="{{ route('absensi.pelajaran') }}" class="btn btn-info me-2">Input Per Mapel</a>
+            <a href="{{ route('absensi.create') }}" class="btn btn-primary">+ Tambah Absensi</a>
+        @endif
     </div>
 </div>
 <form method="GET" class="mb-3 d-flex" action="{{ route('absensi.index') }}">


### PR DESCRIPTION
## Summary
- hide mapel input and add absensi actions when admin views the absensi list

## Testing
- `composer install --no-progress` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_686bebb7a444832ba4fd96c4cdc85ccf