### PR TITLE
Add task list and editing

### DIFF
--- a/resources/views/input_nilai/opsi.blade.php
+++ b/resources/views/input_nilai/opsi.blade.php
@@ -11,6 +11,9 @@
     <li class="list-group-item">
         <a href="{{ route('input-nilai.tugas.form', [$mapel->id, $kelas]) }}">Masukkan Nilai Tugas</a>
     </li>
+    <li class="list-group-item">
+        <a href="{{ route('input-nilai.tugas.list', [$mapel->id, $kelas]) }}">Daftar Nilai Tugas</a>
+    </li>
 </ul>
 <a href="{{ route('input-nilai.kelas', $mapel->id) }}" class="btn btn-secondary mt-3">Kembali</a>
 @endsection

--- a/resources/views/input_nilai/tugas_edit.blade.php
+++ b/resources/views/input_nilai/tugas_edit.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.app')
+
+@section('title', 'Edit Nilai Tugas')
+
+@section('content')
+<h1 class="mb-3">{{ $mapel->nama }} - Kelas {{ $kelas }}</h1>
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach($errors->all() as $err)
+                <li>{{ $err }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+<form method="POST" action="{{ route('input-nilai.tugas.update', [$mapel->id, $kelas, $nomor]) }}">
+    @csrf
+    @method('PUT')
+    <div class="mb-3">
+        <label>Nomor Tugas</label>
+        <input type="number" name="nomor" class="form-control" value="{{ $nomor }}" readonly>
+    </div>
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>Nama Siswa</th>
+                <th>Nilai</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($siswa as $s)
+                <tr>
+                    <td>{{ $s->nama }}</td>
+                    <td><input type="number" name="nilai[{{ $s->id }}]" class="form-control" min="0" max="100" value="{{ $nilai[$s->id] }}"></td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+    <button class="btn btn-success">Simpan</button>
+    <a href="{{ route('input-nilai.tugas.list', [$mapel->id, $kelas]) }}" class="btn btn-secondary">Batal</a>
+</form>
+@endsection

--- a/resources/views/input_nilai/tugas_list.blade.php
+++ b/resources/views/input_nilai/tugas_list.blade.php
@@ -1,0 +1,32 @@
+@extends('layouts.app')
+
+@section('title', 'Daftar Nilai Tugas')
+
+@section('content')
+<h1 class="mb-3">{{ $mapel->nama }} - Kelas {{ $kelas }}</h1>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@foreach($tugas as $nomor => $list)
+    <h4 class="mt-4">Tugas Nomor {{ $nomor }} <a href="{{ route('input-nilai.tugas.edit', [$mapel->id, $kelas, $nomor]) }}" class="btn btn-sm btn-warning ms-2">Edit</a></h4>
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>Nama Siswa</th>
+                <th>Nilai</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($siswa as $s)
+                <tr>
+                    <td>{{ $s->nama }}</td>
+                    <td>
+                        {{ optional($list->firstWhere('penilaian.siswa_id', $s->id))->nilai ?? '-' }}
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+@endforeach
+<a href="{{ route('input-nilai.opsi', [$mapel->id, $kelas]) }}" class="btn btn-secondary mt-3">Kembali</a>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,6 +61,9 @@ Route::middleware(['auth', 'role:guru'])->group(function () {
     Route::get('/input-nilai/{mapel}/{kelas}/absensi', [\App\Http\Controllers\InputNilaiController::class, 'absensi'])->name('input-nilai.nilai');
     Route::get('/input-nilai/{mapel}/{kelas}/tugas', [\App\Http\Controllers\InputNilaiController::class, 'tugasForm'])->name('input-nilai.tugas.form');
     Route::post('/input-nilai/{mapel}/{kelas}/tugas', [\App\Http\Controllers\InputNilaiController::class, 'tugasStore'])->name('input-nilai.tugas.store');
+    Route::get('/input-nilai/{mapel}/{kelas}/tugas-list', [\App\Http\Controllers\InputNilaiController::class, 'tugasList'])->name('input-nilai.tugas.list');
+    Route::get('/input-nilai/{mapel}/{kelas}/tugas/{nomor}/edit', [\App\Http\Controllers\InputNilaiController::class, 'tugasEditForm'])->name('input-nilai.tugas.edit');
+    Route::put('/input-nilai/{mapel}/{kelas}/tugas/{nomor}', [\App\Http\Controllers\InputNilaiController::class, 'tugasUpdate'])->name('input-nilai.tugas.update');
 });
 
 // Profile dapat diakses oleh semua user yang login

--- a/tests/Feature/TugasListPageTest.php
+++ b/tests/Feature/TugasListPageTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TugasListPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_tugas_list_page_can_be_opened(): void
+    {
+        $user = User::factory()->create(['role' => 'guru']);
+        $guru = \App\Models\Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+            'user_id' => $user->id,
+        ]);
+        $mapel = \App\Models\MataPelajaran::create(['nama' => 'Matematika']);
+        \App\Models\Pengajaran::create(['guru_id' => $guru->id, 'mapel_id' => $mapel->id, 'kelas' => '1A']);
+        $siswa = \App\Models\Siswa::create([
+            'nama' => 'Siswa',
+            'nisn' => '1',
+            'kelas' => '1A',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+        ]);
+        $penilaian = \App\Models\Penilaian::create([
+            'siswa_id' => $siswa->id,
+            'mapel_id' => $mapel->id,
+            'semester' => 1,
+        ]);
+        \App\Models\NilaiTugas::create([
+            'penilaian_id' => $penilaian->id,
+            'nomor' => 1,
+            'nilai' => 80,
+        ]);
+
+        $response = $this->actingAs($user)->get("/input-nilai/{$mapel->id}/1A/tugas-list");
+
+        $response->assertOk();
+        $response->assertSee('Tugas Nomor 1');
+    }
+}


### PR DESCRIPTION
## Summary
- enable teachers to list and edit task scores
- add routes and controller methods for listing and editing tasks
- update options page to link to the new task list
- include new Blade views for listing and editing
- test page loads

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_686d47e86fe4832b989bba8a32180d1e