### PR TITLE
Replace assignment number with name

### DIFF
--- a/app/Http/Controllers/InputNilaiController.php
+++ b/app/Http/Controllers/InputNilaiController.php
@@ -127,7 +127,7 @@ class InputNilaiController extends Controller
         }
 
         $validated = $request->validate([
-            'nomor' => 'required|integer|min:1',
+            'nama' => 'required|string|max:255',
             'nilai.*' => 'nullable|integer|min:0|max:100',
         ]);
 
@@ -144,7 +144,7 @@ class InputNilaiController extends Controller
 
             \App\Models\NilaiTugas::updateOrCreate([
                 'penilaian_id' => $penilaian->id,
-                'nomor' => $validated['nomor'],
+                'nama' => $validated['nama'],
             ], [
                 'nilai' => $nilai,
             ]);
@@ -171,7 +171,7 @@ class InputNilaiController extends Controller
         $tugas = NilaiTugas::whereHas('penilaian', function ($q) use ($mapel, $siswaIds) {
             $q->where('mapel_id', $mapel->id)
                 ->whereIn('siswa_id', $siswaIds);
-        })->get()->groupBy('nomor');
+        })->get()->groupBy('nama');
 
         return view('input_nilai.tugas_list', [
             'mapel' => $mapel,
@@ -181,7 +181,7 @@ class InputNilaiController extends Controller
         ]);
     }
 
-    public function tugasEditForm(MataPelajaran $mapel, $kelas, $nomor)
+    public function tugasEditForm(MataPelajaran $mapel, $kelas, $nama)
     {
         $guru = $this->guru();
         $exists = Pengajaran::where('guru_id', $guru->id)
@@ -198,7 +198,7 @@ class InputNilaiController extends Controller
             $nilaiTugas = NilaiTugas::whereHas('penilaian', function ($q) use ($mapel, $s) {
                 $q->where('mapel_id', $mapel->id)
                     ->where('siswa_id', $s->id);
-            })->where('nomor', $nomor)->first();
+            })->where('nama', $nama)->first();
             $nilai[$s->id] = $nilaiTugas->nilai ?? null;
         }
 
@@ -206,12 +206,12 @@ class InputNilaiController extends Controller
             'mapel' => $mapel,
             'kelas' => $kelas,
             'siswa' => $siswa,
-            'nomor' => $nomor,
+            'nama' => $nama,
             'nilai' => $nilai,
         ]);
     }
 
-    public function tugasUpdate(Request $request, MataPelajaran $mapel, $kelas, $nomor)
+    public function tugasUpdate(Request $request, MataPelajaran $mapel, $kelas, $nama)
     {
         $guru = $this->guru();
         $exists = Pengajaran::where('guru_id', $guru->id)
@@ -235,14 +235,14 @@ class InputNilaiController extends Controller
 
             if ($nilai === null || $nilai === '') {
                 NilaiTugas::where('penilaian_id', $penilaian->id)
-                    ->where('nomor', $nomor)
+                    ->where('nama', $nama)
                     ->delete();
                 continue;
             }
 
             NilaiTugas::updateOrCreate([
                 'penilaian_id' => $penilaian->id,
-                'nomor' => $nomor,
+                'nama' => $nama,
             ], [
                 'nilai' => $nilai,
             ]);

--- a/app/Models/NilaiTugas.php
+++ b/app/Models/NilaiTugas.php
@@ -10,7 +10,7 @@ class NilaiTugas extends Model
     use HasFactory;
 
     protected $table = 'nilai_tugas';
-    protected $fillable = ['penilaian_id', 'nomor', 'nilai'];
+    protected $fillable = ['penilaian_id', 'nama', 'nilai'];
 
     public function penilaian()
     {

--- a/database/migrations/2025_07_09_000000_update_nilai_tugas_nama_column.php
+++ b/database/migrations/2025_07_09_000000_update_nilai_tugas_nama_column.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('nilai_tugas', function (Blueprint $table) {
+            $table->dropUnique(['penilaian_id', 'nomor']);
+            $table->string('nama');
+            $table->dropColumn('nomor');
+            $table->unique(['penilaian_id', 'nama']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('nilai_tugas', function (Blueprint $table) {
+            $table->dropUnique(['penilaian_id', 'nama']);
+            $table->unsignedSmallInteger('nomor');
+            $table->unique(['penilaian_id', 'nomor']);
+            $table->dropColumn('nama');
+        });
+    }
+};

--- a/resources/views/input_nilai/tugas.blade.php
+++ b/resources/views/input_nilai/tugas.blade.php
@@ -19,8 +19,8 @@
 <form method="POST" action="{{ route('input-nilai.tugas.store', [$mapel->id, $kelas]) }}">
     @csrf
     <div class="mb-3">
-        <label>Nomor Tugas</label>
-        <input type="number" name="nomor" class="form-control" min="1" required>
+        <label>Nama Tugas</label>
+        <input type="text" name="nama" class="form-control" required>
     </div>
     <table class="table table-bordered">
         <thead>

--- a/resources/views/input_nilai/tugas_edit.blade.php
+++ b/resources/views/input_nilai/tugas_edit.blade.php
@@ -13,12 +13,12 @@
         </ul>
     </div>
 @endif
-<form method="POST" action="{{ route('input-nilai.tugas.update', [$mapel->id, $kelas, $nomor]) }}">
+<form method="POST" action="{{ route('input-nilai.tugas.update', [$mapel->id, $kelas, $nama]) }}">
     @csrf
     @method('PUT')
     <div class="mb-3">
-        <label>Nomor Tugas</label>
-        <input type="number" name="nomor" class="form-control" value="{{ $nomor }}" readonly>
+        <label>Nama Tugas</label>
+        <input type="text" name="nama" class="form-control" value="{{ $nama }}" readonly>
     </div>
     <table class="table table-bordered">
         <thead>

--- a/resources/views/input_nilai/tugas_list.blade.php
+++ b/resources/views/input_nilai/tugas_list.blade.php
@@ -8,11 +8,11 @@
 @if(session('success'))
     <div class="alert alert-success">{{ session('success') }}</div>
 @endif
-@forelse($tugas as $nomor => $list)
+@forelse($tugas as $nama => $list)
 <div class="mb-3">
     <div class="d-flex align-items-center">
-        <h5 class="mb-0 flex-grow-1">Tugas Nomor {{ $nomor }}</h5>
-        <a href="{{ route('input-nilai.tugas.edit', [$mapel->id, $kelas, $nomor]) }}" class="btn btn-sm btn-warning me-2">Edit</a>
+        <h5 class="mb-0 flex-grow-1">Nama Tugas: {{ $nama }}</h5>
+        <a href="{{ route('input-nilai.tugas.edit', [$mapel->id, $kelas, $nama]) }}" class="btn btn-sm btn-warning me-2">Edit</a>
         <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#tugasModal{{ $loop->iteration }}">Lihat</button>
     </div>
 
@@ -20,7 +20,7 @@
         <div class="modal-dialog modal-lg modal-dialog-scrollable">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="tugasModalLabel{{ $loop->iteration }}">Tugas Nomor {{ $nomor }}</h5>
+                    <h5 class="modal-title" id="tugasModalLabel{{ $loop->iteration }}">Nama Tugas: {{ $nama }}</h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body p-0">

--- a/routes/web.php
+++ b/routes/web.php
@@ -62,8 +62,8 @@ Route::middleware(['auth', 'role:guru'])->group(function () {
     Route::get('/input-nilai/{mapel}/{kelas}/tugas', [\App\Http\Controllers\InputNilaiController::class, 'tugasForm'])->name('input-nilai.tugas.form');
     Route::post('/input-nilai/{mapel}/{kelas}/tugas', [\App\Http\Controllers\InputNilaiController::class, 'tugasStore'])->name('input-nilai.tugas.store');
     Route::get('/input-nilai/{mapel}/{kelas}/tugas-list', [\App\Http\Controllers\InputNilaiController::class, 'tugasList'])->name('input-nilai.tugas.list');
-    Route::get('/input-nilai/{mapel}/{kelas}/tugas/{nomor}/edit', [\App\Http\Controllers\InputNilaiController::class, 'tugasEditForm'])->name('input-nilai.tugas.edit');
-    Route::put('/input-nilai/{mapel}/{kelas}/tugas/{nomor}', [\App\Http\Controllers\InputNilaiController::class, 'tugasUpdate'])->name('input-nilai.tugas.update');
+    Route::get('/input-nilai/{mapel}/{kelas}/tugas/{nama}/edit', [\App\Http\Controllers\InputNilaiController::class, 'tugasEditForm'])->name('input-nilai.tugas.edit');
+    Route::put('/input-nilai/{mapel}/{kelas}/tugas/{nama}', [\App\Http\Controllers\InputNilaiController::class, 'tugasUpdate'])->name('input-nilai.tugas.update');
 });
 
 // Profile dapat diakses oleh semua user yang login

--- a/tests/Feature/TugasListPageTest.php
+++ b/tests/Feature/TugasListPageTest.php
@@ -38,14 +38,14 @@ class TugasListPageTest extends TestCase
         ]);
         \App\Models\NilaiTugas::create([
             'penilaian_id' => $penilaian->id,
-            'nomor' => 1,
+            'nama' => 'Ulangan Harian',
             'nilai' => 80,
         ]);
 
         $response = $this->actingAs($user)->get("/input-nilai/{$mapel->id}/1A/tugas-list");
 
         $response->assertOk();
-        $response->assertSee('Tugas Nomor 1');
+        $response->assertSee('Nama Tugas: Ulangan Harian');
         $response->assertSee('tugasModal1');
     }
 }


### PR DESCRIPTION
## Summary
- allow free text for task names and store them in a new column
- rename controller parameters from `nomor` to `nama`
- update migration, routes, and blade templates to use task names
- adapt feature test for the new wording

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686db09dfff8832ba0bec5d91f57ce77