### PR TITLE
Fix dropping index in nilai_tugas migration

### DIFF
--- a/database/migrations/2025_07_09_000000_update_nilai_tugas_nama_column.php
+++ b/database/migrations/2025_07_09_000000_update_nilai_tugas_nama_column.php
@@ -7,11 +7,14 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up(): void
     {
+        // Add the new column and unique index first so the foreign key on
+        // `penilaian_id` always has an index available. Afterwards the old
+        // unique index can be safely removed along with the column.
         Schema::table('nilai_tugas', function (Blueprint $table) {
-            $table->dropUnique(['penilaian_id', 'nomor']);
             $table->string('nama');
-            $table->dropColumn('nomor');
             $table->unique(['penilaian_id', 'nama']);
+            $table->dropUnique(['penilaian_id', 'nomor']);
+            $table->dropColumn('nomor');
         });
     }
 


### PR DESCRIPTION
## Summary
- fix migration order so `nilai_tugas` keeps an index for the foreign key when dropping `nomor`

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686db23230f0832b8ef1c1212a793354