### PR TITLE
Fix tugas list pagination

### DIFF
--- a/app/Http/Controllers/InputNilaiController.php
+++ b/app/Http/Controllers/InputNilaiController.php
@@ -174,11 +174,13 @@ class InputNilaiController extends Controller
         })->select('nama')->distinct()->orderBy('nama');
 
         $names = $query->paginate(10);
+        $names->getCollection()->transform(fn ($item) => $item->nama);
+        $nameValues = $names->items();
 
         $tugas = NilaiTugas::whereHas('penilaian', function ($q) use ($mapel, $siswaIds) {
             $q->where('mapel_id', $mapel->id)
                 ->whereIn('siswa_id', $siswaIds);
-        })->whereIn('nama', $names->items())->get()->groupBy('nama');
+        })->whereIn('nama', $nameValues)->get()->groupBy('nama');
 
         return view('input_nilai.tugas_list', [
             'mapel' => $mapel,


### PR DESCRIPTION
## Summary
- transform paginated records into a string collection for tugas names
- build tugas query using name array from paginator

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_686fdd25bb50832b909a2d57c49ec9ba