### PR TITLE
Fix modal layout on tugas list

### DIFF
--- a/resources/views/input_nilai/tugas_list.blade.php
+++ b/resources/views/input_nilai/tugas_list.blade.php
@@ -17,46 +17,48 @@
             </tr>
         </thead>
         <tbody>
-            @foreach($namaTugas as $nama)
+            @foreach($namaTugas as $index => $nama)
                 <tr>
                     <td>{{ $nama }}</td>
                     <td>
                         <a href="{{ route('input-nilai.tugas.edit', [$mapel->id, $kelas, $nama]) }}" class="btn btn-sm btn-warning me-2">Edit</a>
-                        <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#tugasModal{{ $loop->iteration }}">Lihat</button>
+                        <button class="btn btn-sm btn-primary" data-bs-toggle="modal" data-bs-target="#tugasModal{{ $index + 1 }}">Lihat</button>
                     </td>
                 </tr>
-
-                <div class="modal fade" id="tugasModal{{ $loop->iteration }}" tabindex="-1" aria-labelledby="tugasModalLabel{{ $loop->iteration }}" aria-hidden="true">
-                    <div class="modal-dialog modal-lg modal-dialog-scrollable">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <h5 class="modal-title" id="tugasModalLabel{{ $loop->iteration }}">Nama Tugas: {{ $nama }}</h5>
-                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-                            </div>
-                            <div class="modal-body p-0">
-                                <table class="table table-bordered mb-0">
-                                    <thead>
-                                        <tr>
-                                            <th>Nama Siswa</th>
-                                            <th>Nilai</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        @foreach($siswa as $s)
-                                            <tr>
-                                                <td>{{ $s->nama }}</td>
-                                                <td>{{ optional($tugas[$nama]->firstWhere('penilaian.siswa_id', $s->id))->nilai ?? '-' }}</td>
-                                            </tr>
-                                        @endforeach
-                                    </tbody>
-                                </table>
-                            </div>
-                        </div>
-                    </div>
-                </div>
             @endforeach
         </tbody>
     </table>
+
+    @foreach($namaTugas as $index => $nama)
+        <div class="modal fade" id="tugasModal{{ $index + 1 }}" tabindex="-1" aria-labelledby="tugasModalLabel{{ $index + 1 }}" aria-hidden="true">
+            <div class="modal-dialog modal-lg modal-dialog-scrollable">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="tugasModalLabel{{ $index + 1 }}">Nama Tugas: {{ $nama }}</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body p-0">
+                        <table class="table table-bordered mb-0">
+                            <thead>
+                                <tr>
+                                    <th>Nama Siswa</th>
+                                    <th>Nilai</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($siswa as $s)
+                                    <tr>
+                                        <td>{{ $s->nama }}</td>
+                                        <td>{{ optional($tugas[$nama]->firstWhere('penilaian.siswa_id', $s->id))->nilai ?? '-' }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    @endforeach
 
     {{ $namaTugas->links() }}
 @else


### PR DESCRIPTION
## Summary
- move modals outside of `<tbody>` so the markup is valid

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686fe14ab67c832bb091bd39a1f908b8