### PR TITLE
Add dashboard for teacher role

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -7,13 +7,19 @@ use App\Models\Guru;
 use App\Models\MataPelajaran;
 use App\Models\Kelas;
 use App\Models\Absensi;
+use App\Models\Pengajaran;
+use App\Models\Jadwal;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Auth;
 
 class DashboardController extends Controller
 {
     public function index()
     {
+        if (Auth::user()?->role === 'guru') {
+            return $this->dashboardGuru();
+        }
+
         $today = Carbon::today();
 
         $absensiPerHari = Absensi::selectRaw('tanggal, count(*) as total')
@@ -31,6 +37,31 @@ class DashboardController extends Controller
             'totalKelas' => Kelas::count(),
             'absensiHariIni' => Absensi::where('tanggal', $today->toDateString())->where('status', 'Hadir')->count(),
             'absensiPerHari' => $absensiPerHari,
+        ]);
+    }
+
+    private function dashboardGuru()
+    {
+        $guru = Guru::where('user_id', Auth::id())->first();
+        if (!$guru) {
+            abort(403);
+        }
+
+        $hari = Carbon::now()->locale('id')->isoFormat('dddd');
+
+        $jadwalHariIni = Jadwal::with(['kelas', 'mapel'])
+            ->where('guru_id', $guru->id)
+            ->where('hari', $hari)
+            ->orderBy('jam_mulai')
+            ->get();
+
+        $kelasMapel = Pengajaran::with('mapel')
+            ->where('guru_id', $guru->id)
+            ->get();
+
+        return view('guru.dashboard', [
+            'jadwalHariIni' => $jadwalHariIni,
+            'kelasMapel' => $kelasMapel,
         ]);
     }
 }

--- a/resources/views/guru/dashboard.blade.php
+++ b/resources/views/guru/dashboard.blade.php
@@ -1,0 +1,58 @@
+@extends('layouts.app')
+
+@section('title', 'Dashboard Guru')
+
+@section('content')
+<h1 class="mb-4">Dashboard Guru</h1>
+
+<div class="mb-4">
+    <h4>Jadwal Hari Ini</h4>
+    @if($jadwalHariIni->isEmpty())
+        <p>Tidak ada jadwal mengajar hari ini.</p>
+    @else
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>Jam</th>
+                    <th>Kelas</th>
+                    <th>Mapel</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($jadwalHariIni as $j)
+                <tr>
+                    <td>{{ $j->jam_mulai }} - {{ $j->jam_selesai }}</td>
+                    <td>{{ $j->kelas->nama }}</td>
+                    <td>{{ $j->mapel->nama }}</td>
+                </tr>
+                @endforeach
+            </tbody>
+        </table>
+    @endif
+</div>
+
+<div class="mb-4">
+    <h4>Kelas &amp; Mapel Diampu</h4>
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>Kelas</th>
+                <th>Mapel</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($kelasMapel as $p)
+            <tr>
+                <td>{{ $p->kelas }}</td>
+                <td>{{ $p->mapel->nama }}</td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>
+
+<div class="mb-4">
+    <a href="{{ route('input-nilai.index') }}" class="btn btn-primary me-2">Input Nilai</a>
+    <a href="{{ route('absensi.pelajaran') }}" class="btn btn-secondary">Absensi</a>
+</div>
+@endsection

--- a/tests/Feature/GuruDashboardTest.php
+++ b/tests/Feature/GuruDashboardTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\TahunAjaran;
+use App\Models\Pengajaran;
+use App\Models\Jadwal;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GuruDashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guru_dashboard_shows_schedule(): void
+    {
+        $user = User::factory()->create(['role' => 'guru']);
+        $guru = Guru::create([
+            'nuptk' => '999',
+            'nama' => 'Guru Test',
+            'tempat_lahir' => 'Bandung',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+            'user_id' => $user->id,
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+
+        Pengajaran::create([
+            'guru_id' => $guru->id,
+            'mapel_id' => $mapel->id,
+            'kelas' => $kelas->nama,
+        ]);
+
+        Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => now()->locale('id')->isoFormat('dddd'),
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+
+        $response = $this->actingAs($user)->get('/dashboard');
+
+        $response->assertOk();
+        $response->assertSee('Dashboard Guru');
+        $response->assertSee('Jadwal Hari Ini');
+    }
+}


### PR DESCRIPTION
## Summary
- customize DashboardController to show teacher-specific data
- implement dashboard view for teachers
- add feature test covering teacher dashboard

## Testing
- `composer install --ignore-platform-req=php`
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_687192f1ac54832ba7be049b13db0a8d