### PR TITLE
Add email to student profile

### DIFF
--- a/resources/views/siswa/show.blade.php
+++ b/resources/views/siswa/show.blade.php
@@ -7,6 +7,7 @@
 <table class="table table-bordered w-50">
     <tr><th>Nama</th><td>{{ $siswa->nama }}</td></tr>
     <tr><th>NISN</th><td>{{ $siswa->nisn }}</td></tr>
+    <tr><th>Email</th><td>{{ $siswa->user?->email ?? '-' }}</td></tr>
     <tr><th>Kelas</th><td>{{ $siswa->kelas }}</td></tr>
     <tr><th>Tempat Lahir</th><td>{{ $siswa->tempat_lahir }}</td></tr>
     <tr><th>Jenis Kelamin</th><td>{{ $siswa->jenis_kelamin }}</td></tr>

--- a/tests/Feature/StudentProfileTest.php
+++ b/tests/Feature/StudentProfileTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Siswa;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StudentProfileTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_student_profile_displays_email(): void
+    {
+        $user = User::factory()->create(['role' => 'siswa']);
+        Siswa::create([
+            'nama' => 'Siswa',
+            'nisn' => '1234567890',
+            'kelas' => 'X',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+            'user_id' => $user->id,
+        ]);
+
+        $response = $this->actingAs($user)->get('/saya');
+        $response->assertOk();
+        $response->assertSee($user->email);
+    }
+}
+


### PR DESCRIPTION
## Summary
- show related user's email in student profile view
- test student profile email visibility

## Testing
- `composer update`
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68761f5bb6bc832ba21071bbd805f2da