### PR TITLE
Add email support in teacher management

### DIFF
--- a/app/Http/Controllers/GuruController.php
+++ b/app/Http/Controllers/GuruController.php
@@ -15,7 +15,8 @@ class GuruController extends Controller
         if ($search) {
             $query->where(function ($q) use ($search) {
                 $q->where('nama', 'like', "%{$search}%")
-                    ->orWhere('nuptk', 'like', "%{$search}%");
+                    ->orWhere('nuptk', 'like', "%{$search}%")
+                    ->orWhere('email', 'like', "%{$search}%");
             });
         }
 
@@ -34,6 +35,7 @@ public function store(Request $request)
     Guru::create($request->validate([
         'nuptk' => 'required|unique:guru',
         'nama' => 'required',
+        'email' => 'nullable|email|unique:guru',
         'tempat_lahir' => 'required',
         'jenis_kelamin' => 'required',
         'tanggal_lahir' => 'required|date'
@@ -52,6 +54,7 @@ public function update(Request $request, Guru $guru)
     $guru->update($request->validate([
         'nuptk' => 'required|unique:guru,nuptk,' . $guru->id,
         'nama' => 'required',
+        'email' => 'nullable|email|unique:guru,email,' . $guru->id,
         'tempat_lahir' => 'required',
         'jenis_kelamin' => 'required',
         'tanggal_lahir' => 'required|date'

--- a/app/Models/Guru.php
+++ b/app/Models/Guru.php
@@ -13,6 +13,7 @@ class Guru extends Model
     protected $fillable = [
         'nuptk',
         'nama',
+        'email',
         'tempat_lahir',
         'jenis_kelamin',
         'tanggal_lahir',

--- a/database/migrations/2025_07_10_000001_add_email_to_guru_table.php
+++ b/database/migrations/2025_07_10_000001_add_email_to_guru_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('guru', function (Blueprint $table) {
+            $table->string('email')->nullable()->after('nama');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('guru', function (Blueprint $table) {
+            $table->dropColumn('email');
+        });
+    }
+};

--- a/resources/views/guru/create.blade.php
+++ b/resources/views/guru/create.blade.php
@@ -26,6 +26,11 @@
         <x-input-error :messages="$errors->get('nama')" class="mt-1" />
     </div>
     <div class="mb-3">
+        <label>Email</label>
+        <input type="email" name="email" class="form-control">
+        <x-input-error :messages="$errors->get('email')" class="mt-1" />
+    </div>
+    <div class="mb-3">
         <label>Tempat Lahir</label>
         <input type="text" name="tempat_lahir" class="form-control" required>
         <x-input-error :messages="$errors->get('tempat_lahir')" class="mt-1" />

--- a/resources/views/guru/edit.blade.php
+++ b/resources/views/guru/edit.blade.php
@@ -26,6 +26,11 @@
         <x-input-error :messages="$errors->get('nama')" class="mt-1" />
     </div>
     <div class="mb-3">
+        <label>Email</label>
+        <input type="email" name="email" class="form-control" value="{{ $guru->email }}">
+        <x-input-error :messages="$errors->get('email')" class="mt-1" />
+    </div>
+    <div class="mb-3">
         <label>Tempat Lahir</label>
         <input type="text" name="tempat_lahir" class="form-control" value="{{ $guru->tempat_lahir }}" required>
         <x-input-error :messages="$errors->get('tempat_lahir')" class="mt-1" />

--- a/resources/views/guru/index.blade.php
+++ b/resources/views/guru/index.blade.php
@@ -20,6 +20,7 @@
             <th>ID</th>
             <th>NUPTK</th>
             <th>Nama</th>
+            <th>Email</th>
             <th>Tempat Lahir</th>
             <th>Jenis Kelamin</th>
             <th>Tanggal Lahir</th>
@@ -32,6 +33,7 @@
             <td>{{ $g->id }}</td>
             <td>{{ $g->nuptk }}</td>
             <td>{{ $g->nama }}</td>
+            <td>{{ $g->email }}</td>
             <td>{{ $g->tempat_lahir }}</td>
             <td>{{ $g->jenis_kelamin }}</td>
             <td>{{ $g->tanggal_lahir }}</td>


### PR DESCRIPTION
## Summary
- allow storing teacher emails
- show email in teacher listings
- support email on create/edit forms
- enable searching by email

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6878a6d2dddc832ba8c6f0b97b0e9365