### PR TITLE
Use Guru email for user creation

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -50,7 +50,7 @@ class UserController extends Controller
         if ($data['role'] === 'guru') {
             $guru = Guru::findOrFail($data['guru_id']);
             $name = $guru->nuptk.' - '.$guru->nama;
-            $email = $guru->nuptk.'@muhammadiyah.ac.id';
+            $email = $guru->email;
             $password = Carbon::parse($guru->tanggal_lahir)->format('ymd');
         } elseif ($data['role'] === 'siswa') {
             $siswa = Siswa::findOrFail($data['siswa_id']);

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -48,7 +48,7 @@
     <input type="hidden" name="siswa_id" id="siswa-id">
     <datalist id="guru-list">
         @foreach ($guru as $g)
-            <option value="{{ $g->nuptk }} - {{ $g->nama }}" data-id="{{ $g->id }}" data-nuptk="{{ $g->nuptk }}" data-tanggallahir="{{ $g->tanggal_lahir }}"></option>
+            <option value="{{ $g->nuptk }} - {{ $g->nama }}" data-id="{{ $g->id }}" data-nuptk="{{ $g->nuptk }}" data-email="{{ $g->email }}" data-tanggallahir="{{ $g->tanggal_lahir }}"></option>
         @endforeach
     </datalist>
     <datalist id="siswa-list">
@@ -73,7 +73,11 @@ document.addEventListener('DOMContentLoaded', function () {
         const id = type === 'guru' ? opt.dataset.nuptk : opt.dataset.nisn;
         const tgl = opt.dataset.tanggallahir || '';
         if (id) {
-            emailInput.value = id + '@muhammadiyah.ac.id';
+            if (type === 'guru') {
+                emailInput.value = opt.dataset.email || id + '@muhammadiyah.ac.id';
+            } else {
+                emailInput.value = id + '@muhammadiyah.ac.id';
+            }
             if (tgl) {
                 const parts = tgl.split('-');
                 passInput.value = parts[0].slice(2) + parts[1] + parts[2];

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -50,7 +50,7 @@
     <input type="hidden" name="siswa_id" id="siswa-id" value="{{ optional($siswa->firstWhere('user_id', $user->id))->id }}">
     <datalist id="guru-list">
         @foreach ($guru as $g)
-            <option value="{{ $g->nuptk }} - {{ $g->nama }}" data-id="{{ $g->id }}" data-nuptk="{{ $g->nuptk }}" data-tanggallahir="{{ $g->tanggal_lahir }}"></option>
+            <option value="{{ $g->nuptk }} - {{ $g->nama }}" data-id="{{ $g->id }}" data-nuptk="{{ $g->nuptk }}" data-email="{{ $g->email }}" data-tanggallahir="{{ $g->tanggal_lahir }}"></option>
         @endforeach
     </datalist>
     <datalist id="siswa-list">
@@ -75,7 +75,11 @@ document.addEventListener('DOMContentLoaded', function () {
         const id = type === 'guru' ? opt.dataset.nuptk : opt.dataset.nisn;
         const tgl = opt.dataset.tanggallahir || '';
         if (id) {
-            emailInput.value = id + '@muhammadiyah.ac.id';
+            if (type === 'guru') {
+                emailInput.value = opt.dataset.email || id + '@muhammadiyah.ac.id';
+            } else {
+                emailInput.value = id + '@muhammadiyah.ac.id';
+            }
             if (tgl) {
                 const parts = tgl.split('-');
                 passInput.value = parts[0].slice(2) + parts[1] + parts[2];


### PR DESCRIPTION
## Summary
- use Guru's stored email when creating a user account
- include guru email in datalist options
- fill email input from guru record in create/edit user forms

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_688652bb9e5c832b86eb367479deaddd