### PR TITLE
Remove enforced domain for teacher emails

### DIFF
--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -74,7 +74,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const tgl = opt.dataset.tanggallahir || '';
         if (id) {
             if (type === 'guru') {
-                emailInput.value = opt.dataset.email || id + '@muhammadiyah.ac.id';
+                emailInput.value = opt.dataset.email || '';
             } else {
                 emailInput.value = id + '@muhammadiyah.ac.id';
             }

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -76,7 +76,7 @@ document.addEventListener('DOMContentLoaded', function () {
         const tgl = opt.dataset.tanggallahir || '';
         if (id) {
             if (type === 'guru') {
-                emailInput.value = opt.dataset.email || id + '@muhammadiyah.ac.id';
+                emailInput.value = opt.dataset.email || '';
             } else {
                 emailInput.value = id + '@muhammadiyah.ac.id';
             }


### PR DESCRIPTION
## Summary
- allow manual email entry for teacher accounts without default `@muhammadiyah.ac.id` domain

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6886f3423980832bac7b70bb01b9daac