### PR TITLE
Add student schedule view

### DIFF
--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers;
 use App\Models\Siswa;
 use App\Models\Absensi;
 use App\Models\MataPelajaran;
+use App\Models\Jadwal;
+use App\Models\Kelas;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
 
@@ -55,6 +57,29 @@ class StudentController extends Controller
         );
 
         return redirect()->route('student.absensi')->with('success', 'Absensi berhasil dicatat');
+    }
+
+    /**
+     * Display schedule for the logged in student.
+     */
+    public function jadwal()
+    {
+        $siswa = Siswa::where('user_id', Auth::id())->firstOrFail();
+        $kelas = Kelas::where('nama', $siswa->kelas)->first();
+
+        if ($kelas) {
+            $jadwal = Jadwal::with(['mapel', 'guru'])
+                ->where('kelas_id', $kelas->id)
+                ->get()
+                ->groupBy('hari');
+        } else {
+            $jadwal = collect();
+        }
+
+        return view('siswa.jadwal', [
+            'siswa' => $siswa,
+            'jadwal' => $jadwal,
+        ]);
     }
 
 }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -43,6 +43,7 @@
                         <li><a href="{{ route('student.profile') }}" class="dropdown-item"><i class="bi bi-person me-2"></i>Data Diri</a></li>
                         <li><a href="{{ route('student.absensi') }}" class="dropdown-item"><i class="bi bi-person-check me-2"></i>Absensi Saya</a></li>
                         <li><a href="{{ route('student.absen.form') }}" class="dropdown-item"><i class="bi bi-pencil-square me-2"></i>Ambil Absen</a></li>
+                        <li><a href="{{ route('student.jadwal') }}" class="dropdown-item"><i class="bi bi-calendar-week me-2"></i>Jadwal Pelajaran</a></li>
                     @endif
                 </ul>
             </div>

--- a/resources/views/siswa/jadwal.blade.php
+++ b/resources/views/siswa/jadwal.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.app')
+
+@section('title', 'Jadwal Pelajaran')
+
+@section('content')
+<h1 class="mb-3">Jadwal Pelajaran Saya (Kelas {{ $siswa->kelas }})</h1>
+@php $days = ['Senin','Selasa','Rabu','Kamis','Jumat']; @endphp
+@foreach($days as $day)
+    <h4 class="mt-4">{{ $day }}</h4>
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>Mapel</th>
+                <th>Guru</th>
+                <th>Jam</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse($jadwal->get($day, collect()) as $j)
+            <tr>
+                <td>{{ $j->mapel->nama }}</td>
+                <td>{{ $j->guru->nama }}</td>
+                <td>{{ $j->jam_mulai }} - {{ $j->jam_selesai }}</td>
+            </tr>
+            @empty
+            <tr><td colspan="3" class="text-center">Tidak ada jadwal</td></tr>
+            @endforelse
+        </tbody>
+    </table>
+@endforeach
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -91,6 +91,7 @@ Route::middleware(['auth', 'role:siswa'])->group(function () {
     Route::get('/saya/absensi', [StudentController::class, 'absensi'])->name('student.absensi');
     Route::get('/saya/absen', [StudentController::class, 'absenForm'])->name('student.absen.form');
     Route::post('/saya/absen', [StudentController::class, 'absen'])->name('student.absen');
+    Route::get('/saya/jadwal', [StudentController::class, 'jadwal'])->name('student.jadwal');
 });
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/StudentScheduleTest.php
+++ b/tests/Feature/StudentScheduleTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\Siswa;
+use App\Models\Jadwal;
+use App\Models\TahunAjaran;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StudentScheduleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_student_can_view_schedule(): void
+    {
+        $user = User::factory()->create(['role' => 'siswa']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        Siswa::create([
+            'nama' => 'Siswa 1',
+            'nisn' => '123',
+            'kelas' => $kelas->nama,
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+            'user_id' => $user->id,
+        ]);
+        Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+
+        $response = $this->actingAs($user)->get('/saya/jadwal');
+
+        $response->assertOk();
+        $response->assertSee('Jadwal Pelajaran');
+        $response->assertSee($mapel->nama);
+        $response->assertSee($guru->nama);
+    }
+}


### PR DESCRIPTION
## Summary
- implement student schedule route and view
- allow students to view their own schedule and add menu entry
- test student schedule display

## Testing
- `composer install --no-interaction --no-progress`
- `./vendor/bin/phpunit --stop-on-failure tests/Feature/StudentScheduleTest.php`
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_688738ccc69c832b9a926d2d08b8d9c5