### PR TITLE
Enable attendance from student schedule

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -42,7 +42,7 @@
                     @if(Auth::user()->role === 'siswa')
                         <li><a href="{{ route('student.profile') }}" class="dropdown-item"><i class="bi bi-person me-2"></i>Data Diri</a></li>
                         <li><a href="{{ route('student.absensi') }}" class="dropdown-item"><i class="bi bi-person-check me-2"></i>Absensi Saya</a></li>
-                        <li><a href="{{ route('student.absen.form') }}" class="dropdown-item"><i class="bi bi-pencil-square me-2"></i>Ambil Absen</a></li>
+                        <li><a href="{{ route('student.jadwal') }}" class="dropdown-item"><i class="bi bi-pencil-square me-2"></i>Ambil Absen</a></li>
                         <li><a href="{{ route('student.jadwal') }}" class="dropdown-item"><i class="bi bi-calendar-week me-2"></i>Jadwal Pelajaran</a></li>
                     @endif
                 </ul>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -50,7 +50,7 @@
                         @if(Auth::user()->role === 'siswa')
                             <x-dropdown-link :href="route('student.profile')">Data Diri</x-dropdown-link>
                             <x-dropdown-link :href="route('student.absensi')">Absensi Saya</x-dropdown-link>
-                            <x-dropdown-link :href="route('student.absen.form')">Ambil Absen</x-dropdown-link>
+                            <x-dropdown-link :href="route('student.jadwal')">Ambil Absen</x-dropdown-link>
                         @endif
                     </x-slot>
                 </x-dropdown>

--- a/resources/views/siswa/absen_jadwal.blade.php
+++ b/resources/views/siswa/absen_jadwal.blade.php
@@ -3,7 +3,7 @@
 @section('title', 'Ambil Absen')
 
 @section('content')
-<h1>Ambil Absen Hari Ini</h1>
+<h1>Ambil Absen {{ $jadwal->mapel->nama }}</h1>
 @if(session('success'))
     <div class="alert alert-success">{{ session('success') }}</div>
 @endif
@@ -16,18 +16,8 @@
         </ul>
     </div>
 @endif
-<form action="{{ route('student.absen') }}" method="POST">
+<form action="{{ route('student.jadwal.absen', $jadwal->id) }}" method="POST">
     @csrf
-    <div class="mb-3">
-        <label>Mata Pelajaran</label>
-        <select name="mapel_id" class="form-control" required>
-            <option value="">-- Pilih Mapel --</option>
-            @foreach($mapel as $m)
-                <option value="{{ $m->id }}">{{ $m->nama }}</option>
-            @endforeach
-        </select>
-        <x-input-error :messages="$errors->get('mapel_id')" class="mt-1" />
-    </div>
     <div class="mb-3">
         <label>Status</label>
         <select name="status" class="form-control" required>
@@ -40,6 +30,6 @@
         <x-input-error :messages="$errors->get('status')" class="mt-1" />
     </div>
     <button class="btn btn-success">Simpan</button>
-    <a href="{{ route('student.absensi') }}" class="btn btn-secondary">Kembali</a>
+    <a href="{{ route('student.jadwal') }}" class="btn btn-secondary">Kembali</a>
 </form>
 @endsection

--- a/resources/views/siswa/jadwal.blade.php
+++ b/resources/views/siswa/jadwal.blade.php
@@ -13,6 +13,7 @@
                 <th>Mapel</th>
                 <th>Guru</th>
                 <th>Jam</th>
+                <th>Absen</th>
             </tr>
         </thead>
         <tbody>
@@ -21,9 +22,10 @@
                 <td>{{ $j->mapel->nama }}</td>
                 <td>{{ $j->guru->nama }}</td>
                 <td>{{ $j->jam_mulai }} - {{ $j->jam_selesai }}</td>
+                <td><a href="{{ route('student.jadwal.absen.form', $j->id) }}" class="btn btn-sm btn-primary">Ambil Absen</a></td>
             </tr>
             @empty
-            <tr><td colspan="3" class="text-center">Tidak ada jadwal</td></tr>
+            <tr><td colspan="4" class="text-center">Tidak ada jadwal</td></tr>
             @endforelse
         </tbody>
     </table>

--- a/routes/web.php
+++ b/routes/web.php
@@ -89,9 +89,9 @@ Route::middleware('auth')->group(function () {
 Route::middleware(['auth', 'role:siswa'])->group(function () {
     Route::get('/saya', [StudentController::class, 'profil'])->name('student.profile');
     Route::get('/saya/absensi', [StudentController::class, 'absensi'])->name('student.absensi');
-    Route::get('/saya/absen', [StudentController::class, 'absenForm'])->name('student.absen.form');
-    Route::post('/saya/absen', [StudentController::class, 'absen'])->name('student.absen');
     Route::get('/saya/jadwal', [StudentController::class, 'jadwal'])->name('student.jadwal');
+    Route::get('/saya/jadwal/{jadwal}/absen', [StudentController::class, 'jadwalAbsenForm'])->name('student.jadwal.absen.form');
+    Route::post('/saya/jadwal/{jadwal}/absen', [StudentController::class, 'jadwalAbsen'])->name('student.jadwal.absen');
 });
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/StudentScheduleAbsensiTest.php
+++ b/tests/Feature/StudentScheduleAbsensiTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\Siswa;
+use App\Models\Jadwal;
+use App\Models\TahunAjaran;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StudentScheduleAbsensiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_student_can_absen_from_schedule(): void
+    {
+        $user = User::factory()->create(['role' => 'siswa']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        $siswa = Siswa::create([
+            'nama' => 'Siswa 1',
+            'nisn' => '123',
+            'kelas' => $kelas->nama,
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+            'user_id' => $user->id,
+        ]);
+        $jadwal = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+
+        $this->actingAs($user)
+            ->post('/saya/jadwal/'.$jadwal->id.'/absen', [
+                'status' => 'Hadir',
+            ])
+            ->assertRedirect('/saya/jadwal');
+
+        $this->assertDatabaseHas('absensi', [
+            'siswa_id' => $siswa->id,
+            'mapel_id' => $mapel->id,
+            'status' => 'Hadir',
+            'tanggal' => date('Y-m-d'),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- remove old student attendance form
- add schedule-based attendance endpoints
- link to 'Ambil Absen' from schedule menu
- update layouts to use the new route
- test that a student can submit attendance via schedule

## Testing
- `composer install --no-interaction --no-progress --prefer-dist`
- `./vendor/bin/phpunit --filter StudentScheduleAbsensiTest --stop-on-failure`
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68873cf7d4a8832bbc7d26d813dfa912