### PR TITLE
Remove Ambil Absen menu

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -42,7 +42,6 @@
                     @if(Auth::user()->role === 'siswa')
                         <li><a href="{{ route('student.profile') }}" class="dropdown-item"><i class="bi bi-person me-2"></i>Data Diri</a></li>
                         <li><a href="{{ route('student.absensi') }}" class="dropdown-item"><i class="bi bi-person-check me-2"></i>Absensi Saya</a></li>
-                        <li><a href="{{ route('student.jadwal') }}" class="dropdown-item"><i class="bi bi-pencil-square me-2"></i>Ambil Absen</a></li>
                         <li><a href="{{ route('student.jadwal') }}" class="dropdown-item"><i class="bi bi-calendar-week me-2"></i>Jadwal Pelajaran</a></li>
                     @endif
                 </ul>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -50,7 +50,6 @@
                         @if(Auth::user()->role === 'siswa')
                             <x-dropdown-link :href="route('student.profile')">Data Diri</x-dropdown-link>
                             <x-dropdown-link :href="route('student.absensi')">Absensi Saya</x-dropdown-link>
-                            <x-dropdown-link :href="route('student.jadwal')">Ambil Absen</x-dropdown-link>
                         @endif
                     </x-slot>
                 </x-dropdown>

--- a/resources/views/siswa/jadwal.blade.php
+++ b/resources/views/siswa/jadwal.blade.php
@@ -13,7 +13,6 @@
                 <th>Mapel</th>
                 <th>Guru</th>
                 <th>Jam</th>
-                <th>Absen</th>
             </tr>
         </thead>
         <tbody>
@@ -22,10 +21,9 @@
                 <td>{{ $j->mapel->nama }}</td>
                 <td>{{ $j->guru->nama }}</td>
                 <td>{{ $j->jam_mulai }} - {{ $j->jam_selesai }}</td>
-                <td><a href="{{ route('student.jadwal.absen.form', $j->id) }}" class="btn btn-sm btn-primary">Ambil Absen</a></td>
             </tr>
             @empty
-            <tr><td colspan="4" class="text-center">Tidak ada jadwal</td></tr>
+            <tr><td colspan="3" class="text-center">Tidak ada jadwal</td></tr>
             @endforelse
         </tbody>
     </table>


### PR DESCRIPTION
## Summary
- drop the "Ambil Absen" entry from student navigation menus
- remove the Absen column from the student schedule table

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6887a916aa88832b98455c551a9d2198