### PR TITLE
Display attendance history on self attendance form

### DIFF
--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -65,7 +65,12 @@ class StudentController extends Controller
             abort(403);
         }
 
-        return view('siswa.absen_jadwal', compact('jadwal'));
+        $riwayat = Absensi::where('siswa_id', $siswa->id)
+            ->where('mapel_id', $jadwal->mapel_id)
+            ->orderBy('tanggal', 'desc')
+            ->get();
+
+        return view('siswa.absen_jadwal', compact('jadwal', 'riwayat'));
     }
 
     /**

--- a/resources/views/siswa/absen_jadwal.blade.php
+++ b/resources/views/siswa/absen_jadwal.blade.php
@@ -16,6 +16,25 @@
         </ul>
     </div>
 @endif
+@if($riwayat->count())
+    <h4 class="mt-4">Riwayat Absen</h4>
+    <table class="table table-bordered">
+        <thead>
+            <tr>
+                <th>Tanggal</th>
+                <th>Status</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($riwayat as $r)
+            <tr>
+                <td>{{ $r->tanggal }}</td>
+                <td>{{ $r->status }}</td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+@endif
 <form action="{{ route('student.jadwal.absen', $jadwal->id) }}" method="POST">
     @csrf
     <div class="mb-3">

--- a/tests/Feature/StudentScheduleAbsensiListTest.php
+++ b/tests/Feature/StudentScheduleAbsensiListTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\Siswa;
+use App\Models\Jadwal;
+use App\Models\TahunAjaran;
+use App\Models\Absensi;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StudentScheduleAbsensiListTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_absen_form_shows_previous_records(): void
+    {
+        $user = User::factory()->create(['role' => 'siswa']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        $siswa = Siswa::create([
+            'nama' => 'Siswa 1',
+            'nisn' => '123',
+            'kelas' => $kelas->nama,
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+            'user_id' => $user->id,
+        ]);
+        $jadwal = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+
+        Absensi::create([
+            'siswa_id' => $siswa->id,
+            'mapel_id' => $mapel->id,
+            'tanggal' => date('Y-m-d', strtotime('-1 day')),
+            'status' => 'Hadir',
+        ]);
+
+        $response = $this->actingAs($user)->get('/saya/jadwal/'.$jadwal->id.'/absen');
+
+        $response->assertOk();
+        $response->assertSee(date('Y-m-d', strtotime('-1 day')));
+        $response->assertSee('Hadir');
+    }
+}


### PR DESCRIPTION
## Summary
- show prior attendance records in `jadwalAbsenForm`
- render attendance history table on the student's attendance page
- add test ensuring the form lists prior records

## Testing
- `composer install`
- `vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68885f7df9f0832b8e9abf9da007ab1d