### PR TITLE
Add student grade page

### DIFF
--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -6,6 +6,7 @@ use App\Models\Siswa;
 use App\Models\Absensi;
 use App\Models\Jadwal;
 use App\Models\Kelas;
+use App\Models\Penilaian;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
 
@@ -28,6 +29,19 @@ class StudentController extends Controller
         $siswa = Siswa::where('user_id', Auth::id())->firstOrFail();
         $absensi = $siswa->absensi()->with('mapel')->get();
         return view('siswa.absensi', compact('siswa', 'absensi'));
+    }
+
+    /**
+     * Show logged in student's scores.
+     */
+    public function nilai()
+    {
+        $siswa = Siswa::where('user_id', Auth::id())->firstOrFail();
+        $penilaian = Penilaian::with('mapel', 'tugas')
+            ->where('siswa_id', $siswa->id)
+            ->get();
+
+        return view('siswa.nilai', compact('siswa', 'penilaian'));
     }
 
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -42,6 +42,7 @@
                     @if(Auth::user()->role === 'siswa')
                         <li><a href="{{ route('student.profile') }}" class="dropdown-item"><i class="bi bi-person me-2"></i>Data Diri</a></li>
                         <li><a href="{{ route('student.absensi') }}" class="dropdown-item"><i class="bi bi-person-check me-2"></i>Absensi Saya</a></li>
+                        <li><a href="{{ route('student.nilai') }}" class="dropdown-item"><i class="bi bi-clipboard-data me-2"></i>Nilai Saya</a></li>
                         <li><a href="{{ route('student.jadwal') }}" class="dropdown-item"><i class="bi bi-calendar-week me-2"></i>Jadwal Pelajaran</a></li>
                     @endif
                 </ul>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -50,6 +50,7 @@
                         @if(Auth::user()->role === 'siswa')
                             <x-dropdown-link :href="route('student.profile')">Data Diri</x-dropdown-link>
                             <x-dropdown-link :href="route('student.absensi')">Absensi Saya</x-dropdown-link>
+                            <x-dropdown-link :href="route('student.nilai')">Nilai Saya</x-dropdown-link>
                         @endif
                     </x-slot>
                 </x-dropdown>

--- a/resources/views/siswa/nilai.blade.php
+++ b/resources/views/siswa/nilai.blade.php
@@ -1,0 +1,33 @@
+@extends('layouts.app')
+
+@section('title', 'Nilai Saya')
+
+@section('content')
+<h1 class="mb-3">Nilai Saya</h1>
+<table class="table table-bordered">
+    <thead>
+        <tr>
+            <th>Mata Pelajaran</th>
+            <th>Semester</th>
+            <th>Nilai Absensi</th>
+            <th>Nilai Tugas</th>
+            <th>PTS</th>
+            <th>PAT</th>
+            <th>Nilai Raport</th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach($penilaian as $p)
+        <tr>
+            <td>{{ $p->mapel->nama }}</td>
+            <td>{{ $p->semester }}</td>
+            <td>{{ number_format($p->nilai_absensi, 2) }}</td>
+            <td>{{ number_format($p->nilai_tugas, 2) }}</td>
+            <td>{{ $p->pts ?? '-' }}</td>
+            <td>{{ $p->pat ?? '-' }}</td>
+            <td>{{ number_format($p->nilai_raport, 2) }}</td>
+        </tr>
+        @endforeach
+    </tbody>
+</table>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -89,6 +89,7 @@ Route::middleware('auth')->group(function () {
 Route::middleware(['auth', 'role:siswa'])->group(function () {
     Route::get('/saya', [StudentController::class, 'profil'])->name('student.profile');
     Route::get('/saya/absensi', [StudentController::class, 'absensi'])->name('student.absensi');
+    Route::get('/saya/nilai', [StudentController::class, 'nilai'])->name('student.nilai');
     Route::get('/saya/jadwal', [StudentController::class, 'jadwal'])->name('student.jadwal');
     Route::get('/saya/jadwal/{jadwal}/absen', [StudentController::class, 'jadwalAbsenForm'])->name('student.jadwal.absen.form');
     Route::post('/saya/jadwal/{jadwal}/absen', [StudentController::class, 'jadwalAbsen'])->name('student.jadwal.absen');

--- a/tests/Feature/StudentScoreTest.php
+++ b/tests/Feature/StudentScoreTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\MataPelajaran;
+use App\Models\NilaiTugas;
+use App\Models\Penilaian;
+use App\Models\Siswa;
+use App\Models\TahunAjaran;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StudentScoreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_student_can_view_scores(): void
+    {
+        $user = User::factory()->create(['role' => 'siswa']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $siswa = Siswa::create([
+            'nama' => 'Siswa',
+            'nisn' => '123',
+            'kelas' => 'X',
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+            'user_id' => $user->id,
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        $penilaian = Penilaian::create([
+            'siswa_id' => $siswa->id,
+            'mapel_id' => $mapel->id,
+            'semester' => 1,
+            'hadir' => 10,
+            'sakit' => 0,
+            'izin' => 0,
+            'alpha' => 0,
+            'pts' => 80,
+            'pat' => 90,
+        ]);
+        NilaiTugas::create([
+            'penilaian_id' => $penilaian->id,
+            'nama' => 'Tugas 1',
+            'nilai' => 85,
+        ]);
+
+        $response = $this->actingAs($user)->get('/saya/nilai');
+
+        $response->assertOk();
+        $response->assertSee('Nilai Saya');
+        $response->assertSee('IPA');
+        $response->assertSee('80');
+        $response->assertSee('90');
+    }
+}


### PR DESCRIPTION
## Summary
- let students see their grades per subject
- link to the grades page in navigation menus
- test student score page

## Testing
- `./vendor/bin/phpunit --stop-on-failure --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_68886be6798c832baabfc48b64f9e311