### PR TITLE
Add student dashboard

### DIFF
--- a/resources/views/siswa/dashboard.blade.php
+++ b/resources/views/siswa/dashboard.blade.php
@@ -1,0 +1,89 @@
+@extends('layouts.app')
+
+@section('title', 'Dashboard Siswa')
+
+@section('content')
+<h1 class="mb-4">Dashboard Siswa</h1>
+
+<div class="mb-4">
+    <h4>Jadwal Hari Ini</h4>
+    @if($jadwalHariIni->isEmpty())
+        <p>Tidak ada jadwal hari ini.</p>
+    @else
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>Jam</th>
+                    <th>Mapel</th>
+                    <th>Guru</th>
+                </tr>
+            </thead>
+            <tbody>
+            @foreach($jadwalHariIni as $j)
+                <tr>
+                    <td>{{ $j->jam_mulai }} - {{ $j->jam_selesai }}</td>
+                    <td>{{ $j->mapel->nama }}</td>
+                    <td>{{ $j->guru->nama }}</td>
+                </tr>
+            @endforeach
+            </tbody>
+        </table>
+    @endif
+</div>
+
+<div class="mb-4">
+    <h4>Ringkasan Kehadiran</h4>
+    <table class="table table-bordered w-50">
+        <tr><th>Hadir</th><td>{{ $absensiSummary['Hadir'] ?? 0 }}</td></tr>
+        <tr><th>Izin</th><td>{{ $absensiSummary['Izin'] ?? 0 }}</td></tr>
+        <tr><th>Sakit</th><td>{{ $absensiSummary['Sakit'] ?? 0 }}</td></tr>
+        <tr><th>Alpha</th><td>{{ $absensiSummary['Alpha'] ?? 0 }}</td></tr>
+    </table>
+</div>
+
+<div class="mb-4">
+    <h4>Nilai Terbaru</h4>
+    @if($nilaiTerbaru->isEmpty())
+        <p>Belum ada nilai.</p>
+    @else
+        <table class="table table-bordered">
+            <thead>
+                <tr>
+                    <th>Mapel</th>
+                    <th>Semester</th>
+                    <th>Nilai Raport</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($nilaiTerbaru as $n)
+                <tr>
+                    <td>{{ $n->mapel->nama }}</td>
+                    <td>{{ $n->semester }}</td>
+                    <td>{{ number_format($n->nilai_raport, 2) }}</td>
+                </tr>
+                @endforeach
+            </tbody>
+        </table>
+    @endif
+</div>
+
+<div class="mb-4">
+    <h4>Pengumuman</h4>
+    @if(empty($pengumuman))
+        <p>Belum ada pengumuman.</p>
+    @else
+        <ul>
+            @foreach($pengumuman as $p)
+            <li>{{ $p }}</li>
+            @endforeach
+        </ul>
+    @endif
+</div>
+
+<div class="mb-4">
+    <a href="{{ route('student.profile') }}" class="btn btn-primary me-2">Profil</a>
+    <a href="{{ route('student.absensi') }}" class="btn btn-secondary me-2">Absensi</a>
+    <a href="{{ route('student.nilai') }}" class="btn btn-success me-2">Nilai</a>
+    <a href="{{ route('student.jadwal') }}" class="btn btn-info">Jadwal</a>
+</div>
+@endsection

--- a/tests/Feature/StudentDashboardTest.php
+++ b/tests/Feature/StudentDashboardTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\Siswa;
+use App\Models\TahunAjaran;
+use App\Models\Jadwal;
+use App\Models\Absensi;
+use App\Models\Penilaian;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StudentDashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_student_dashboard_shows_summary(): void
+    {
+        $user = User::factory()->create(['role' => 'siswa']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        $siswa = Siswa::create([
+            'nama' => 'Siswa',
+            'nisn' => '123',
+            'kelas' => $kelas->nama,
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+            'user_id' => $user->id,
+        ]);
+        Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => now()->locale('id')->isoFormat('dddd'),
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+        Absensi::create([
+            'siswa_id' => $siswa->id,
+            'mapel_id' => $mapel->id,
+            'tanggal' => date('Y-m-d'),
+            'status' => 'Hadir',
+        ]);
+        Penilaian::create([
+            'siswa_id' => $siswa->id,
+            'mapel_id' => $mapel->id,
+            'semester' => 1,
+            'hadir' => 1,
+            'sakit' => 0,
+            'izin' => 0,
+            'alpha' => 0,
+            'pts' => 80,
+            'pat' => 90,
+        ]);
+
+        $response = $this->actingAs($user)->get('/dashboard');
+
+        $response->assertOk();
+        $response->assertSee('Dashboard Siswa');
+        $response->assertSee('Ringkasan Kehadiran');
+        $response->assertSee('Nilai Terbaru');
+        $response->assertSee('IPA');
+    }
+}


### PR DESCRIPTION
## Summary
- show student dashboard instead of admin dashboard for `role:siswa`
- add schedule, attendance, and score summaries
- provide quick links to student pages
- test student dashboard display

## Testing
- `composer install`
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6888725c0410832b8b4925fa5430e09d