### PR TITLE
Show weekly schedule for teachers

### DIFF
--- a/app/Http/Controllers/AbsensiController.php
+++ b/app/Http/Controllers/AbsensiController.php
@@ -215,12 +215,19 @@ public function update(Request $request, Absensi $absensi)
             $jadwal = collect();
         } else {
             $jadwal = Jadwal::with(['mapel', 'kelas'])
-                        ->where('guru_id', $guru->id)
-                        ->where('hari', $hari)
-                        ->get();
+                ->where('guru_id', $guru->id)
+                ->orderByRaw("CASE hari WHEN 'Senin' THEN 1 WHEN 'Selasa' THEN 2 WHEN 'Rabu' THEN 3 WHEN 'Kamis' THEN 4 WHEN 'Jumat' THEN 5 WHEN 'Sabtu' THEN 6 ELSE 7 END")
+                ->orderBy('jam_mulai')
+                ->get()
+                ->groupBy('hari');
         }
 
-        return view('absensi.pelajaran', compact('jadwal', 'hari', 'tanggal'));
+        $days = ['Senin','Selasa','Rabu','Kamis','Jumat'];
+
+        return view('absensi.pelajaran', [
+            'jadwal' => $jadwal,
+            'days' => $days,
+        ]);
     }
 
     public function pelajaranForm(Request $request, Jadwal $jadwal)

--- a/resources/views/absensi/pelajaran.blade.php
+++ b/resources/views/absensi/pelajaran.blade.php
@@ -3,7 +3,13 @@
 @section('title', 'Jadwal Pelajaran')
 
 @section('content')
-<h1 class="mb-3">Jadwal Hari {{ $hari }}</h1>
+<h1 class="mb-3">
+    @if(Auth::user()->role === 'guru')
+        Jadwal Minggu Ini
+    @else
+        Jadwal Hari {{ $hari }}
+    @endif
+</h1>
 
 @if(Auth::user()->role === 'admin')
 <form method="GET" class="row g-2 mb-3">
@@ -39,14 +45,30 @@
 </form>
 @endif
 
+@if(Auth::user()->role === 'admin')
 <ul class="list-group">
     @forelse($jadwal as $j)
         <li class="list-group-item d-flex justify-content-between align-items-center">
             <span>{{ $j->kelas->nama }} - {{ $j->mapel->nama }} ({{ $j->jam_mulai }} - {{ $j->jam_selesai }})</span>
-            <a href="{{ route('absensi.pelajaran.form', [$j->id, 'tanggal' => $tanggal]) }}" class="btn btn-sm btn-primary">Isi Absen</a>
+            <a href="{{ route('absensi.pelajaran.form', $j->id) }}" class="btn btn-sm btn-primary">Isi Absen</a>
         </li>
     @empty
-        <li class="list-group-item text-center">Tidak ada jadwal{{ Auth::user()->role === 'guru' ? ' hari ini' : '' }}</li>
+        <li class="list-group-item text-center">Tidak ada jadwal</li>
     @endforelse
 </ul>
+@else
+    @foreach($days as $day)
+        <h4 class="mt-4">{{ $day }}</h4>
+        <ul class="list-group mb-3">
+            @forelse($jadwal->get($day, collect()) as $j)
+                <li class="list-group-item d-flex justify-content-between align-items-center">
+                    <span>{{ $j->kelas->nama }} - {{ $j->mapel->nama }} ({{ $j->jam_mulai }} - {{ $j->jam_selesai }})</span>
+                    <a href="{{ route('absensi.pelajaran.form', $j->id) }}" class="btn btn-sm btn-primary">Isi Absen</a>
+                </li>
+            @empty
+                <li class="list-group-item text-center">Tidak ada jadwal</li>
+            @endforelse
+        </ul>
+    @endforeach
+@endif
 @endsection

--- a/tests/Feature/GuruWeeklyScheduleTest.php
+++ b/tests/Feature/GuruWeeklyScheduleTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\TahunAjaran;
+use App\Models\Pengajaran;
+use App\Models\Jadwal;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GuruWeeklyScheduleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_weekly_schedule_grouped_by_day(): void
+    {
+        $user = User::factory()->create(['role' => 'guru']);
+        $guru = Guru::create([
+            'nuptk' => '111',
+            'nama' => 'Guru 1',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+            'user_id' => $user->id,
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'Matematika']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+
+        Pengajaran::create([
+            'guru_id' => $guru->id,
+            'mapel_id' => $mapel->id,
+            'kelas' => $kelas->nama,
+        ]);
+
+        Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+        Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Selasa',
+            'jam_mulai' => '08:00',
+            'jam_selesai' => '09:00',
+        ]);
+
+        $response = $this->actingAs($user)->get('/absensi/pelajaran');
+
+        $response->assertOk();
+        $response->assertSee('Jadwal Minggu Ini');
+        $response->assertSee('Senin');
+        $response->assertSee('Selasa');
+        $response->assertSee($mapel->nama);
+    }
+}


### PR DESCRIPTION
## Summary
- group guru schedule by day and order correctly
- show weekly schedule for teachers
- link directly to absensi form
- test guru weekly schedule grouping

## Testing
- `./vendor/bin/phpunit --filter=GuruWeeklyScheduleTest`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68888c4d4e9c832bb361cd70c2940bbc