### PR TITLE
Allow guru to view absensi index

### DIFF
--- a/app/Http/Controllers/AbsensiController.php
+++ b/app/Http/Controllers/AbsensiController.php
@@ -33,9 +33,9 @@ class AbsensiController extends Controller
 
     public function index(Request $request)
     {
-        if (Auth::user()?->role === 'guru') {
-            return redirect()->route('absensi.pelajaran');
-        }
+        // Previously teachers were redirected to the input-per-mapel page.
+        // The redirect is removed so that teachers can also view the absensi
+        // index page like admins.
         $query = Absensi::with('siswa')->whereHas('siswa', function ($q) {
             $q->whereIn('kelas', $this->kelasGuru());
         });

--- a/tests/Feature/GuruAbsensiIndexTest.php
+++ b/tests/Feature/GuruAbsensiIndexTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\Kelas;
+use App\Models\MataPelajaran;
+use App\Models\TahunAjaran;
+use App\Models\Pengajaran;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GuruAbsensiIndexTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guru_can_see_absensi_index_with_add_button(): void
+    {
+        $user = User::factory()->create(['role' => 'guru']);
+        $guru = Guru::create([
+            'nuptk' => '100',
+            'nama' => 'Guru Test',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+            'user_id' => $user->id,
+        ]);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'Matematika']);
+        Pengajaran::create([
+            'guru_id' => $guru->id,
+            'mapel_id' => $mapel->id,
+            'kelas' => $kelas->nama,
+        ]);
+
+        $response = $this->actingAs($user)->get('/absensi');
+
+        $response->assertOk();
+        $response->assertSee('+ Tambah Absensi');
+    }
+}


### PR DESCRIPTION
## Summary
- let teachers open the absensi index instead of redirecting
- add feature test for teacher visiting the index page

## Testing
- `vendor/bin/phpunit --filter GuruAbsensiIndexTest -v`
- `vendor/bin/phpunit --stop-on-failure --testsuite Feature`

------
https://chatgpt.com/codex/tasks/task_e_6888f6bab300832ba924a315f57a3101