### PR TITLE
Enable attendance date selection for teachers

### DIFF
--- a/app/Http/Controllers/AbsensiController.php
+++ b/app/Http/Controllers/AbsensiController.php
@@ -33,6 +33,10 @@ class AbsensiController extends Controller
 
     public function index(Request $request)
     {
+        if (Auth::user()?->role === 'guru') {
+            return redirect()->route('absensi.pelajaran');
+        }
+
         // Previously teachers were redirected to the input-per-mapel page.
         // The redirect is removed so that teachers can also view the absensi
         // index page like admins.
@@ -237,9 +241,7 @@ public function update(Request $request, Absensi $absensi)
             abort(403);
         }
 
-        $tanggal = Auth::user()?->role === 'guru'
-            ? date('Y-m-d')
-            : $request->input('tanggal', date('Y-m-d'));
+        $tanggal = $request->input('tanggal', date('Y-m-d'));
         $kelasNama = $jadwal->kelas->nama;
         $siswa = Siswa::where('kelas', $kelasNama)->get();
         $absen = Absensi::whereIn('siswa_id', $siswa->pluck('id'))
@@ -268,9 +270,7 @@ public function update(Request $request, Absensi $absensi)
             'status' => 'array',
         ]);
 
-        $tanggal = Auth::user()?->role === 'guru'
-            ? date('Y-m-d')
-            : $request->input('tanggal');
+        $tanggal = $request->input('tanggal', date('Y-m-d'));
         $siswaIds = Siswa::where('kelas', $jadwal->kelas->nama)->pluck('id');
         $statusData = $request->input('status', []);
         foreach ($siswaIds as $id) {

--- a/resources/views/absensi/pelajaran_form.blade.php
+++ b/resources/views/absensi/pelajaran_form.blade.php
@@ -16,16 +16,12 @@
         </ul>
     </div>
 @endif
-@if(auth()->user()->role !== 'guru')
 <form method="GET" class="row g-2 mb-3">
     <div class="col-auto">
         <input type="date" name="tanggal" value="{{ $tanggal }}" class="form-control" onchange="this.form.submit()">
     </div>
     <noscript class="col-auto"><button class="btn btn-primary">Tampilkan</button></noscript>
 </form>
-@else
-<p class="mb-3">Tanggal: {{ $tanggal }}</p>
-@endif
 <form action="{{ route('absensi.pelajaran.store', $jadwal->id) }}" method="POST">
     @csrf
     <input type="hidden" name="tanggal" value="{{ $tanggal }}">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -37,7 +37,7 @@
                             <li><a href="{{ route('input-nilai.index') }}" class="dropdown-item"><i class="bi bi-pencil-square me-2"></i>Input Nilai</a></li>
                         @endif
                         <li><a href="{{ route('penilaian.index') }}" class="dropdown-item"><i class="bi bi-list-check me-2"></i>Penilaian</a></li>
-                        <li><a href="{{ route('absensi.index') }}" class="dropdown-item"><i class="bi bi-person-check me-2"></i>Absensi Siswa</a></li>
+                        <li><a href="{{ route('absensi.pelajaran') }}" class="dropdown-item"><i class="bi bi-person-check me-2"></i>Absensi Siswa</a></li>
                     @endif
                     @if(Auth::user()->role === 'siswa')
                         <li><a href="{{ route('student.profile') }}" class="dropdown-item"><i class="bi bi-person me-2"></i>Data Diri</a></li>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -45,7 +45,7 @@
                                 <x-dropdown-link :href="route('input-nilai.index')">Input Nilai</x-dropdown-link>
                             @endif
                             <x-dropdown-link :href="route('penilaian.index')">Penilaian</x-dropdown-link>
-                            <x-dropdown-link :href="route('absensi.index')">Absensi Siswa</x-dropdown-link>
+                            <x-dropdown-link :href="route('absensi.pelajaran')">Absensi Siswa</x-dropdown-link>
                         @endif
                         @if(Auth::user()->role === 'siswa')
                             <x-dropdown-link :href="route('student.profile')">Data Diri</x-dropdown-link>

--- a/tests/Feature/GuruAbsensiIndexTest.php
+++ b/tests/Feature/GuruAbsensiIndexTest.php
@@ -45,7 +45,6 @@ class GuruAbsensiIndexTest extends TestCase
 
         $response = $this->actingAs($user)->get('/absensi');
 
-        $response->assertOk();
-        $response->assertSee('+ Tambah Absensi');
+        $response->assertRedirect('/absensi/pelajaran');
     }
 }

--- a/tests/Feature/GuruAbsensiScheduleFlowTest.php
+++ b/tests/Feature/GuruAbsensiScheduleFlowTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\TahunAjaran;
+use App\Models\Pengajaran;
+use App\Models\Jadwal;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GuruAbsensiScheduleFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guru_can_navigate_schedule_and_change_date(): void
+    {
+        $user = User::factory()->create(['role' => 'guru']);
+        $guru = Guru::create([
+            'nuptk' => '200',
+            'nama' => 'Guru Test',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+            'user_id' => $user->id,
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'Matematika']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        Pengajaran::create([
+            'guru_id' => $guru->id,
+            'mapel_id' => $mapel->id,
+            'kelas' => $kelas->nama,
+        ]);
+        $jadwal = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+
+        // Dashboard contains link to schedule
+        $this->actingAs($user)
+            ->get('/dashboard')
+            ->assertSee('/absensi/pelajaran');
+
+        // Schedule page shows the lesson
+        $this->actingAs($user)
+            ->get('/absensi/pelajaran')
+            ->assertOk()
+            ->assertSee($mapel->nama);
+
+        // Absen form with custom date is visible
+        $date = '2024-08-20';
+        $this->actingAs($user)
+            ->get('/absensi/pelajaran/'.$jadwal->id.'?tanggal='.$date)
+            ->assertOk()
+            ->assertSee('value="'.$date.'"', false);
+    }
+}
+


### PR DESCRIPTION
## Summary
- update menu links to point to the schedule page
- redirect `/absensi` to the schedule for teachers
- allow teachers to choose the attendance date
- always show the date field on the attendance form
- add feature tests covering the new flow

## Testing
- `composer install --no-interaction --quiet`
- `./vendor/bin/phpunit --testdox --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_68897e4a7b0c832b8629ce85ad31a8de