### PR TITLE
Disable future schedule attendance

### DIFF
--- a/resources/views/siswa/jadwal.blade.php
+++ b/resources/views/siswa/jadwal.blade.php
@@ -4,7 +4,13 @@
 
 @section('content')
 <h1 class="mb-3">Jadwal Pelajaran Saya (Kelas {{ $siswa->kelas }})</h1>
-@php $days = ['Senin','Selasa','Rabu','Kamis','Jumat']; @endphp
+@php
+    use Carbon\Carbon;
+    $days = ['Senin','Selasa','Rabu','Kamis','Jumat'];
+    $dayMap = ['Minggu' => 0, 'Senin' => 1, 'Selasa' => 2, 'Rabu' => 3, 'Kamis' => 4, 'Jumat' => 5, 'Sabtu' => 6];
+    $currentDayIndex = Carbon::now()->dayOfWeek;
+    $currentTime = Carbon::now()->format('H:i');
+@endphp
 @foreach($days as $day)
     <h4 class="mt-4">{{ $day }}</h4>
     <table class="table table-bordered">
@@ -18,12 +24,20 @@
         </thead>
         <tbody>
             @forelse($jadwal->get($day, collect()) as $j)
+            @php
+                $jadwalIndex = $dayMap[$j->hari] ?? 7;
+                $isFuture = $jadwalIndex > $currentDayIndex || ($jadwalIndex == $currentDayIndex && $j->jam_mulai > $currentTime);
+            @endphp
             <tr>
                 <td>{{ $j->mapel->nama }}</td>
                 <td>{{ $j->guru->nama }}</td>
                 <td>{{ $j->jam_mulai }} - {{ $j->jam_selesai }}</td>
                 <td>
-                    <a href="{{ route('student.jadwal.absen.form', $j->id) }}" class="btn btn-sm btn-primary">Ambil Absen</a>
+                    @if($isFuture)
+                        <button class="btn btn-sm btn-primary" disabled>Ambil Absen</button>
+                    @else
+                        <a href="{{ route('student.jadwal.absen.form', $j->id) }}" class="btn btn-sm btn-primary">Ambil Absen</a>
+                    @endif
                 </td>
             </tr>
             @empty

--- a/tests/Feature/StudentScheduleFutureButtonTest.php
+++ b/tests/Feature/StudentScheduleFutureButtonTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\Siswa;
+use App\Models\Jadwal;
+use App\Models\TahunAjaran;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Carbon\Carbon;
+
+class StudentScheduleFutureButtonTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_future_schedule_button_disabled(): void
+    {
+        Carbon::setTestNow('2024-07-01 08:00:00'); // Monday
+
+        $user = User::factory()->create(['role' => 'siswa']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        Siswa::create([
+            'nama' => 'Siswa 1',
+            'nisn' => '123',
+            'kelas' => $kelas->nama,
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+            'user_id' => $user->id,
+        ]);
+        // Schedule later today
+        $future = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '09:00',
+            'jam_selesai' => '10:00',
+        ]);
+
+        $response = $this->actingAs($user)->get('/saya/jadwal');
+
+        $response->assertOk();
+        $response->assertSee('<button class="btn btn-sm btn-primary" disabled>Ambil Absen</button>', false);
+        $response->assertDontSee(route('student.jadwal.absen.form', $future->id));
+    }
+}


### PR DESCRIPTION
## Summary
- disable "Ambil Absen" button for schedule items that are still in the future
- test disabled button for future schedules

## Testing
- `composer install`
- `./vendor/bin/phpunit --testsuite Feature --stop-on-failure`
- `./vendor/bin/phpunit --stop-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_688989e98c4c832b9441da7fb8c016ec