### PR TITLE
Restrict attendance to active schedule slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Aplikasi Sistem Informasi Akademik berbasis Laravel.
 
 ## Fitur
 - Login Multi-Role (Admin, Guru, Siswa)
-- Tambah Absensi Siswa
+- Tambah Absensi Siswa (hanya saat jam pelajaran berlangsung)
 - Rekap dan Absensi per Pelajaran
 - Input dan Cetak Rapor
 - Manajemen Siswa & Kelas

--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -9,6 +9,7 @@ use App\Models\Kelas;
 use App\Models\Penilaian;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
+use Carbon\Carbon;
 
 class StudentController extends Controller
 {
@@ -79,6 +80,14 @@ class StudentController extends Controller
             abort(403);
         }
 
+        $now = Carbon::now();
+        $hari = $now->locale('id')->isoFormat('dddd');
+        $time = $now->format('H:i');
+
+        if ($hari !== $jadwal->hari || $time < $jadwal->jam_mulai || $time > $jadwal->jam_selesai) {
+            abort(403);
+        }
+
         $riwayat = Absensi::where('siswa_id', $siswa->id)
             ->where('mapel_id', $jadwal->mapel_id)
             ->orderBy('tanggal', 'desc')
@@ -95,6 +104,14 @@ class StudentController extends Controller
         $siswa = Siswa::where('user_id', Auth::id())->firstOrFail();
         $kelas = Kelas::where('nama', $siswa->kelas)->first();
         if (!$kelas || $jadwal->kelas_id !== $kelas->id) {
+            abort(403);
+        }
+
+        $now = Carbon::now();
+        $hari = $now->locale('id')->isoFormat('dddd');
+        $time = $now->format('H:i');
+
+        if ($hari !== $jadwal->hari || $time < $jadwal->jam_mulai || $time > $jadwal->jam_selesai) {
             abort(403);
         }
 

--- a/resources/views/siswa/jadwal.blade.php
+++ b/resources/views/siswa/jadwal.blade.php
@@ -26,17 +26,19 @@
             @forelse($jadwal->get($day, collect()) as $j)
             @php
                 $jadwalIndex = $dayMap[$j->hari] ?? 7;
-                $isFuture = $jadwalIndex > $currentDayIndex || ($jadwalIndex == $currentDayIndex && $j->jam_mulai > $currentTime);
+                $isActive = $jadwalIndex == $currentDayIndex &&
+                           $currentTime >= $j->jam_mulai &&
+                           $currentTime <= $j->jam_selesai;
             @endphp
             <tr>
                 <td>{{ $j->mapel->nama }}</td>
                 <td>{{ $j->guru->nama }}</td>
                 <td>{{ $j->jam_mulai }} - {{ $j->jam_selesai }}</td>
                 <td>
-                    @if($isFuture)
-                        <button class="btn btn-sm btn-primary" disabled>Ambil Absen</button>
-                    @else
+                    @if($isActive)
                         <a href="{{ route('student.jadwal.absen.form', $j->id) }}" class="btn btn-sm btn-primary">Ambil Absen</a>
+                    @else
+                        <button class="btn btn-sm btn-primary" disabled>Ambil Absen</button>
                     @endif
                 </td>
             </tr>

--- a/tests/Feature/StudentScheduleAbsensiListTest.php
+++ b/tests/Feature/StudentScheduleAbsensiListTest.php
@@ -9,6 +9,7 @@ use App\Models\Kelas;
 use App\Models\Siswa;
 use App\Models\Jadwal;
 use App\Models\TahunAjaran;
+use Carbon\Carbon;
 use App\Models\Absensi;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -19,6 +20,8 @@ class StudentScheduleAbsensiListTest extends TestCase
 
     public function test_absen_form_shows_previous_records(): void
     {
+        Carbon::setTestNow('2024-07-01 07:30:00');
+
         $user = User::factory()->create(['role' => 'siswa']);
         $guru = Guru::create([
             'nuptk' => '1',


### PR DESCRIPTION
## Summary
- enable attendance button only during the lesson
- forbid accessing attendance routes outside their schedule
- update tests for the new restriction
- document the time-based attendance rule

## Testing
- `php artisan test`
- `vendor/bin/phpunit --filter StudentScheduleAbsensiTest tests/Feature/StudentScheduleAbsensiTest.php -v`
- `vendor/bin/phpunit --filter StudentScheduleFutureButtonTest tests/Feature/StudentScheduleFutureButtonTest.php -v`


------
https://chatgpt.com/codex/tasks/task_e_68898e279cf4832b8c6758b835a545d5