### PR TITLE
Adjust login screen spacing

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -32,14 +32,16 @@
             </label>
         </div>
 
-        <div class="flex items-center justify-end mt-4">
+        <div class="mt-4">
             @if (Route::has('password.request'))
                 <a class="underline text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 dark:focus:ring-offset-gray-800" href="{{ route('password.request') }}">
                     {{ __('Forgot your password?') }}
                 </a>
             @endif
+        </div>
 
-            <x-primary-button class="ml-3">
+        <div class="flex justify-end mt-4">
+            <x-primary-button>
                 {{ __('Log in') }}
             </x-primary-button>
         </div>


### PR DESCRIPTION
## Summary
- give `Forgot your password?` link its own row
- push the login button to a separate row

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688a5b5b95c0832bb04599f76df876d0