### PR TITLE
Include homeroom classes in teacher class list

### DIFF
--- a/app/Http/Controllers/PenilaianController.php
+++ b/app/Http/Controllers/PenilaianController.php
@@ -25,8 +25,10 @@ class PenilaianController extends Controller
         if (!$guru) {
             return [];
         }
+        $pengajaranKelas = Pengajaran::where('guru_id', $guru->id)->pluck('kelas');
+        $waliKelas = Kelas::where('guru_id', $guru->id)->pluck('nama');
 
-        return Pengajaran::where('guru_id', $guru->id)->pluck('kelas')->toArray();
+        return $pengajaranKelas->merge($waliKelas)->unique()->toArray();
     }
 
     public function index(Request $request)


### PR DESCRIPTION
## Summary
- allow teachers to view classes they teach and homeroom classes by merging class lists
- ensure merged class list is unique for full coverage

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_688f03a438a8832babb410757b8cf262