### PR TITLE
Select class before subject when inputting grades

### DIFF
--- a/app/Http/Controllers/InputNilaiController.php
+++ b/app/Http/Controllers/InputNilaiController.php
@@ -22,24 +22,24 @@ class InputNilaiController extends Controller
     public function index()
     {
         $guru = $this->guru();
+        $kelasList = Pengajaran::where('guru_id', $guru->id)
+            ->pluck('kelas')
+            ->unique();
+        return view('input_nilai.index', ['kelasList' => $kelasList]);
+    }
+
+    public function mapel($kelas)
+    {
+        $guru = $this->guru();
         $mapelList = Pengajaran::where('guru_id', $guru->id)
+            ->where('kelas', $kelas)
             ->with('mapel')
             ->get()
             ->pluck('mapel')
             ->unique('id');
-        return view('input_nilai.index', ['mapelList' => $mapelList]);
-    }
-
-    public function kelas(MataPelajaran $mapel)
-    {
-        $guru = $this->guru();
-        $kelasList = Pengajaran::where('guru_id', $guru->id)
-            ->where('mapel_id', $mapel->id)
-            ->pluck('kelas')
-            ->unique();
-        return view('input_nilai.kelas', [
-            'mapel' => $mapel,
-            'kelasList' => $kelasList,
+        return view('input_nilai.mapel', [
+            'kelas' => $kelas,
+            'mapelList' => $mapelList,
         ]);
     }
 

--- a/resources/views/input_nilai/index.blade.php
+++ b/resources/views/input_nilai/index.blade.php
@@ -3,11 +3,11 @@
 @section('title', 'Input Nilai')
 
 @section('content')
-<h1 class="mb-3">Pilih Mata Pelajaran</h1>
+<h1 class="mb-3">Pilih Kelas</h1>
 <ul class="list-group">
-    @foreach($mapelList as $m)
+    @foreach($kelasList as $k)
         <li class="list-group-item">
-            <a href="{{ route('input-nilai.kelas', $m->id) }}">{{ $m->nama }}</a>
+            <a href="{{ route('input-nilai.mapel', $k) }}">{{ $k }}</a>
         </li>
     @endforeach
 </ul>

--- a/resources/views/input_nilai/mapel.blade.php
+++ b/resources/views/input_nilai/mapel.blade.php
@@ -1,13 +1,13 @@
 @extends('layouts.app')
 
-@section('title', 'Pilih Kelas')
+@section('title', 'Pilih Mata Pelajaran')
 
 @section('content')
-<h1 class="mb-3">{{ $mapel->nama }} - Pilih Kelas</h1>
+<h1 class="mb-3">{{ $kelas }} - Pilih Mata Pelajaran</h1>
 <ul class="list-group">
-    @foreach($kelasList as $k)
+    @foreach($mapelList as $m)
         <li class="list-group-item">
-            <a href="{{ route('input-nilai.opsi', [$mapel->id, $k]) }}">{{ $k }}</a>
+            <a href="{{ route('input-nilai.opsi', [$m->id, $kelas]) }}">{{ $m->nama }}</a>
         </li>
     @endforeach
 </ul>

--- a/resources/views/input_nilai/opsi.blade.php
+++ b/resources/views/input_nilai/opsi.blade.php
@@ -25,5 +25,5 @@
         <a href="{{ route('input-nilai.pat.list', [$mapel->id, $kelas, $semester]) }}">Masukkan Nilai PAT</a>
     </li>
 </ul>
-<a href="{{ route('input-nilai.kelas', $mapel->id) }}" class="btn btn-secondary mt-3">Kembali</a>
+<a href="{{ route('input-nilai.mapel', $kelas) }}" class="btn btn-secondary mt-3">Kembali</a>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,7 +55,7 @@ Route::middleware(['auth', 'role:guru'])->group(function () {
     Route::get('/kelas-saya', [GuruKelasController::class, 'index'])->name('guru.kelas');
     Route::get('/nilai-kelas', [GuruKelasController::class, 'nilaiKelas'])->name('guru.nilai-kelas');
     Route::get('/input-nilai', [\App\Http\Controllers\InputNilaiController::class, 'index'])->name('input-nilai.index');
-    Route::get('/input-nilai/{mapel}', [\App\Http\Controllers\InputNilaiController::class, 'kelas'])->name('input-nilai.kelas');
+    Route::get('/input-nilai/kelas/{kelas}', [\App\Http\Controllers\InputNilaiController::class, 'mapel'])->name('input-nilai.mapel');
     Route::get('/input-nilai/{mapel}/{kelas}', [\App\Http\Controllers\InputNilaiController::class, 'opsi'])->name('input-nilai.opsi');
     Route::get('/input-nilai/{mapel}/{kelas}/absensi', [\App\Http\Controllers\InputNilaiController::class, 'absensi'])->name('input-nilai.nilai');
     Route::get('/input-nilai/{mapel}/{kelas}/{semester}/tugas', [\App\Http\Controllers\InputNilaiController::class, 'tugasForm'])->name('input-nilai.tugas.form');


### PR DESCRIPTION
## Summary
- show teacher's classes before selecting subjects
- choose subject after selecting a class with new view and route

## Testing
- `composer install --no-interaction --no-progress`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_688f09b6cb20832b870b4611ac674dc5