### PR TITLE
Add automatic schedule generation

### DIFF
--- a/resources/views/jadwal/index.blade.php
+++ b/resources/views/jadwal/index.blade.php
@@ -5,7 +5,13 @@
 @section('content')
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1>Jadwal Pelajaran</h1>
-    <a href="{{ route('jadwal.create') }}" class="btn btn-primary">+ Tambah Jadwal</a>
+    <div class="d-flex gap-2">
+        <form action="{{ route('jadwal.generate') }}" method="POST">
+            @csrf
+            <button class="btn btn-success">Generate Jadwal</button>
+        </form>
+        <a href="{{ route('jadwal.create') }}" class="btn btn-primary">+ Tambah Jadwal</a>
+    </div>
 </div>
 <form method="GET" action="{{ route('jadwal.index') }}" class="mb-3 d-flex">
     <select name="kelas" class="form-select me-2" onchange="this.form.submit()">
@@ -18,6 +24,9 @@
 </form>
 @if(session('success'))
     <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if(session('error'))
+    <div class="alert alert-danger">{{ session('error') }}</div>
 @endif
 @php $days = ['Senin','Selasa','Rabu','Kamis','Jumat']; @endphp
 @foreach($days as $day)

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,7 @@ Route::middleware(['auth', 'role:admin'])->group(function () {
     Route::resource('kelas', KelasController::class)->except('show');
     Route::resource('users', UserController::class)->except('show');
     Route::resource('pengajaran', PengajaranController::class)->except('show');
+    Route::post('/jadwal/generate', [JadwalController::class, 'generate'])->name('jadwal.generate');
     Route::resource('jadwal', JadwalController::class)->except('show');
     Route::get('/siswa-export', [SiswaController::class, 'export'])->name('siswa.export');
 });

--- a/tests/Feature/JadwalGenerateTest.php
+++ b/tests/Feature/JadwalGenerateTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\Pengajaran;
+use App\Models\Jadwal;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class JadwalGenerateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_generate_schedule_with_four_hours_per_subject_and_no_teacher_conflict(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+        $teacher = Guru::create([
+            'nuptk' => '500',
+            'nama' => 'Guru Generate',
+            'tempat_lahir' => 'Bandung',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'Matematika']);
+        $waliA = Guru::create([
+            'nuptk' => '501',
+            'nama' => 'Wali A',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+        ]);
+        $waliB = Guru::create([
+            'nuptk' => '502',
+            'nama' => 'Wali B',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+        ]);
+        $ta = \App\Models\TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelasA = Kelas::create(['nama' => 'A', 'guru_id' => $waliA->id, 'tahun_ajaran_id' => $ta->id]);
+        $kelasB = Kelas::create(['nama' => 'B', 'guru_id' => $waliB->id, 'tahun_ajaran_id' => $ta->id]);
+
+        Pengajaran::create(['guru_id' => $teacher->id, 'mapel_id' => $mapel->id, 'kelas' => $kelasA->nama]);
+        Pengajaran::create(['guru_id' => $teacher->id, 'mapel_id' => $mapel->id, 'kelas' => $kelasB->nama]);
+
+        $this->actingAs($admin)->post('/jadwal/generate')->assertRedirect('/jadwal');
+
+        $this->assertEquals(8, Jadwal::count());
+        $this->assertEquals(4, Jadwal::where('kelas_id', $kelasA->id)->where('mapel_id', $mapel->id)->count());
+        $this->assertEquals(4, Jadwal::where('kelas_id', $kelasB->id)->where('mapel_id', $mapel->id)->count());
+
+        $times = Jadwal::where('guru_id', $teacher->id)->get()->map(fn($j) => $j->hari . ' ' . $j->jam_mulai);
+        $this->assertEquals($times->count(), $times->unique()->count());
+    }
+
+    public function test_non_admin_cannot_access_generate_schedule_endpoint(): void
+    {
+        $user = User::factory()->create(['role' => 'guru']);
+        $this->actingAs($user)->post('/jadwal/generate')->assertStatus(403);
+    }
+}


### PR DESCRIPTION
## Summary
- add `/jadwal/generate` route and controller method to build weekly schedules automatically
- expose "Generate Jadwal" button and error display in schedule index
- cover generation with feature tests ensuring four hours per mapel and admin-only access

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_688f14956a5c832b9848c17d4b498607