### PR TITLE
Ensure consecutive subject periods in schedule generation

### DIFF
--- a/app/Http/Controllers/JadwalController.php
+++ b/app/Http/Controllers/JadwalController.php
@@ -183,7 +183,7 @@ class JadwalController extends Controller
                             }
                             $prevSlot = date('H:i', strtotime($slot[0] . ' -1 hour'));
                             $nextSlot = date('H:i', strtotime($slot[0] . ' +1 hour'));
-                            if (in_array($prevSlot, $daySlots[$day]) && in_array($nextSlot, $daySlots[$day])) {
+                            if ($dayCounts[$day] == 1 && !in_array($prevSlot, $daySlots[$day]) && !in_array($nextSlot, $daySlots[$day])) {
                                 continue;
                             }
                             $data = [

--- a/tests/Feature/JadwalGenerateTest.php
+++ b/tests/Feature/JadwalGenerateTest.php
@@ -68,6 +68,13 @@ class JadwalGenerateTest extends TestCase
 
             foreach ($grouped as $entries) {
                 $this->assertLessThanOrEqual(2, $entries->count());
+                if ($entries->count() === 2) {
+                    $sorted = $entries->sortBy('jam_mulai')->values();
+                    $this->assertEquals(
+                        date('H:i', strtotime($sorted[0]->jam_mulai . ' +1 hour')),
+                        $sorted[1]->jam_mulai
+                    );
+                }
             }
 
             $this->assertGreaterThanOrEqual(2, $grouped->count());


### PR DESCRIPTION
## Summary
- make schedule generator place a subject's second hour directly adjacent to the first
- test that generated schedules keep double sessions consecutive

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68943513df44832b878c80211a7dd98f