### PR TITLE
Improve schedule generator with retries

### DIFF
--- a/tests/Feature/JadwalGenerateTest.php
+++ b/tests/Feature/JadwalGenerateTest.php
@@ -86,4 +86,109 @@ class JadwalGenerateTest extends TestCase
         $user = User::factory()->create(['role' => 'guru']);
         $this->actingAs($user)->post('/jadwal/generate')->assertStatus(403);
     }
+
+    public function test_generate_schedule_for_all_classes_without_slot_errors(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+
+        $teacherA = Guru::create([
+            'nuptk' => '600',
+            'nama' => 'Guru A',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1985-01-01',
+        ]);
+        $teacherB = Guru::create([
+            'nuptk' => '601',
+            'nama' => 'Guru B',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1986-01-01',
+        ]);
+
+        $mapel1 = MataPelajaran::create(['nama' => 'Matematika']);
+        $mapel2 = MataPelajaran::create(['nama' => 'Bahasa']);
+
+        $waliA = Guru::create([
+            'nuptk' => '602',
+            'nama' => 'Wali A',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+        ]);
+        $waliB = Guru::create([
+            'nuptk' => '603',
+            'nama' => 'Wali B',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+        ]);
+        $ta = \App\Models\TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelasA = Kelas::create(['nama' => 'A', 'guru_id' => $waliA->id, 'tahun_ajaran_id' => $ta->id]);
+        $kelasB = Kelas::create(['nama' => 'B', 'guru_id' => $waliB->id, 'tahun_ajaran_id' => $ta->id]);
+
+        Pengajaran::create(['guru_id' => $teacherA->id, 'mapel_id' => $mapel1->id, 'kelas' => $kelasA->nama]);
+        Pengajaran::create(['guru_id' => $teacherB->id, 'mapel_id' => $mapel2->id, 'kelas' => $kelasA->nama]);
+        Pengajaran::create(['guru_id' => $teacherA->id, 'mapel_id' => $mapel1->id, 'kelas' => $kelasB->nama]);
+        Pengajaran::create(['guru_id' => $teacherB->id, 'mapel_id' => $mapel2->id, 'kelas' => $kelasB->nama]);
+
+        $response = $this->actingAs($admin)->post('/jadwal/generate');
+        $response->assertRedirect('/jadwal');
+        $response->assertSessionMissing('error');
+
+        $this->assertEquals(16, Jadwal::count());
+
+        foreach ([$kelasA, $kelasB] as $kelas) {
+            foreach ([$mapel1, $mapel2] as $mapel) {
+                $this->assertEquals(4, Jadwal::where('kelas_id', $kelas->id)->where('mapel_id', $mapel->id)->count());
+            }
+        }
+    }
+
+    public function test_generate_schedule_skips_classes_without_pengajaran(): void
+    {
+        $admin = User::factory()->create(['role' => 'admin']);
+
+        $teacher = Guru::create([
+            'nuptk' => '700',
+            'nama' => 'Guru C',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1987-01-01',
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPS']);
+
+        $waliA = Guru::create([
+            'nuptk' => '701',
+            'nama' => 'Wali C',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1991-01-01',
+        ]);
+        $waliB = Guru::create([
+            'nuptk' => '702',
+            'nama' => 'Wali D',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1991-01-01',
+        ]);
+        $ta = \App\Models\TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelasA = Kelas::create(['nama' => 'C', 'guru_id' => $waliA->id, 'tahun_ajaran_id' => $ta->id]);
+        $kelasB = Kelas::create(['nama' => 'D', 'guru_id' => $waliB->id, 'tahun_ajaran_id' => $ta->id]);
+
+        Pengajaran::create(['guru_id' => $teacher->id, 'mapel_id' => $mapel->id, 'kelas' => $kelasA->nama]);
+
+        $this->actingAs($admin)->post('/jadwal/generate')->assertRedirect('/jadwal');
+
+        $this->assertEquals(4, Jadwal::where('kelas_id', $kelasA->id)->count());
+        $this->assertEquals(0, Jadwal::where('kelas_id', $kelasB->id)->count());
+    }
 }


### PR DESCRIPTION
## Summary
- Rework schedule generation using shuffled day/slot order, retries, and usage balancing
- Skip classes with no teaching assignments and abort early if none exist
- Add tests ensuring schedules generate without slot errors and empty classes are ignored

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68944d816e48832b98f305a1c176f725