### PR TITLE
feat: show loading overlay during schedule generation

### DIFF
--- a/resources/views/jadwal/index.blade.php
+++ b/resources/views/jadwal/index.blade.php
@@ -3,10 +3,17 @@
 @section('title', 'Jadwal Pelajaran')
 
 @section('content')
+<div id="loading-overlay" class="position-fixed top-0 start-0 w-100 h-100 bg-white bg-opacity-75 d-flex flex-column justify-content-center align-items-center" style="display:none; z-index:1050;">
+    <div class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">Loading...</span>
+    </div>
+    <div class="mt-2">Sedang menggenerasi jadwal...</div>
+</div>
+
 <div class="d-flex justify-content-between align-items-center mb-3">
     <h1>Jadwal Pelajaran</h1>
     <div class="d-flex gap-2">
-        <form action="{{ route('jadwal.generate') }}" method="POST">
+        <form id="generate-form" action="{{ route('jadwal.generate') }}" method="POST">
             @csrf
             <button class="btn btn-success">Generate Jadwal</button>
         </form>
@@ -64,4 +71,12 @@
     </table>
 </div>
 @endforeach
+@endsection
+
+@section('scripts')
+<script>
+    document.getElementById('generate-form').addEventListener('submit', function () {
+        document.getElementById('loading-overlay').style.display = 'flex';
+    });
+</script>
 @endsection


### PR DESCRIPTION
## Summary
- show progress overlay with spinner while generating schedule

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6894586e3604832b87178800ee2205ae