### PR TITLE
Sort schedules by start time

### DIFF
--- a/app/Http/Controllers/AbsensiController.php
+++ b/app/Http/Controllers/AbsensiController.php
@@ -199,7 +199,7 @@ public function update(Request $request, Absensi $absensi)
                 $jadwalQuery->where('mapel_id', $request->mapel_id);
             }
 
-            $jadwal = $jadwalQuery->get();
+            $jadwal = $jadwalQuery->orderBy('jam_mulai')->get();
             $kelasOptions = Kelas::all();
             $mapelOptions = MataPelajaran::all();
             $hariOptions = array_values($hariMap);

--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -57,6 +57,7 @@ class StudentController extends Controller
         if ($kelas) {
             $jadwal = Jadwal::with(['mapel', 'guru'])
                 ->where('kelas_id', $kelas->id)
+                ->orderBy('jam_mulai')
                 ->get()
                 ->groupBy('hari');
         } else {

--- a/tests/Feature/StudentScheduleSortingTest.php
+++ b/tests/Feature/StudentScheduleSortingTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\Siswa;
+use App\Models\Jadwal;
+use App\Models\TahunAjaran;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Carbon\Carbon;
+
+class StudentScheduleSortingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_schedule_sorted_by_start_time(): void
+    {
+        Carbon::setTestNow('2024-07-01 00:00:00');
+
+        $user = User::factory()->create(['role' => 'siswa']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'Matematika']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        Siswa::create([
+            'nama' => 'Siswa 1',
+            'nisn' => '123',
+            'kelas' => $kelas->nama,
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+            'user_id' => $user->id,
+        ]);
+
+        // Create schedules out of order
+        Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '09:00',
+            'jam_selesai' => '10:00',
+        ]);
+        Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+
+        $response = $this->actingAs($user)->get('/saya/jadwal');
+
+        $response->assertSeeInOrder(['07:00', '09:00']);
+    }
+}


### PR DESCRIPTION
## Summary
- sort student schedule entries by start time
- ensure admin schedule view lists sessions chronologically
- add regression test for student schedule ordering

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_689619703a98832b804f11f97f5d4f27