### PR TITLE
Auto-fill attendance date based on schedule day

### DIFF
--- a/app/Http/Controllers/AbsensiController.php
+++ b/app/Http/Controllers/AbsensiController.php
@@ -14,6 +14,7 @@ use App\Exports\RekapAbsensiExport;
 use Maatwebsite\Excel\Facades\Excel;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
+use Carbon\Carbon;
 
 class AbsensiController extends Controller
 {
@@ -227,10 +228,16 @@ public function update(Request $request, Absensi $absensi)
         }
 
         $days = ['Senin','Selasa','Rabu','Kamis','Jumat'];
+        $startOfWeek = Carbon::now()->startOfWeek();
+        $dates = [];
+        foreach ($days as $index => $day) {
+            $dates[$day] = $startOfWeek->copy()->addDays($index)->format('Y-m-d');
+        }
 
         return view('absensi.pelajaran', [
             'jadwal' => $jadwal,
             'days' => $days,
+            'dates' => $dates,
         ]);
     }
 

--- a/resources/views/absensi/pelajaran.blade.php
+++ b/resources/views/absensi/pelajaran.blade.php
@@ -50,7 +50,7 @@
     @forelse($jadwal as $j)
         <li class="list-group-item d-flex justify-content-between align-items-center">
             <span>{{ $j->kelas->nama }} - {{ $j->mapel->nama }} ({{ $j->jam_mulai }} - {{ $j->jam_selesai }})</span>
-            <a href="{{ route('absensi.pelajaran.form', $j->id) }}" class="btn btn-sm btn-primary">Isi Absen</a>
+            <a href="{{ route('absensi.pelajaran.form', ['jadwal' => $j->id, 'tanggal' => $tanggal]) }}" class="btn btn-sm btn-primary">Isi Absen</a>
         </li>
     @empty
         <li class="list-group-item text-center">Tidak ada jadwal</li>
@@ -63,7 +63,7 @@
             @forelse($jadwal->get($day, collect()) as $j)
                 <li class="list-group-item d-flex justify-content-between align-items-center">
                     <span>{{ $j->kelas->nama }} - {{ $j->mapel->nama }} ({{ $j->jam_mulai }} - {{ $j->jam_selesai }})</span>
-                    <a href="{{ route('absensi.pelajaran.form', $j->id) }}" class="btn btn-sm btn-primary">Isi Absen</a>
+                    <a href="{{ route('absensi.pelajaran.form', ['jadwal' => $j->id, 'tanggal' => $dates[$day]]) }}" class="btn btn-sm btn-primary">Isi Absen</a>
                 </li>
             @empty
                 <li class="list-group-item text-center">Tidak ada jadwal</li>


### PR DESCRIPTION
## Summary
- Map each weekday to its real date for the current week
- Include the mapped date in attendance form links for admin and teachers

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_689620c78330832ba63c8c0de526f6a7