### PR TITLE
Allow homeroom teachers to view all class assessments

### DIFF
--- a/app/Http/Controllers/PenilaianController.php
+++ b/app/Http/Controllers/PenilaianController.php
@@ -42,13 +42,21 @@ class PenilaianController extends Controller
         if ($user && $user->role === 'guru') {
             $guru = Guru::where('user_id', $user->id)->first();
             if ($guru) {
-                $query->whereExists(function ($sub) use ($guru) {
-                    $sub->select(DB::raw(1))
-                        ->from('pengajaran')
-                        ->join('siswa', 'pengajaran.kelas', '=', 'siswa.kelas')
-                        ->whereColumn('siswa.id', 'penilaian.siswa_id')
-                        ->whereColumn('pengajaran.mapel_id', 'penilaian.mapel_id')
-                        ->where('pengajaran.guru_id', $guru->id);
+                $query->where(function ($q) use ($guru) {
+                    $q->whereExists(function ($sub) use ($guru) {
+                        $sub->select(DB::raw(1))
+                            ->from('pengajaran')
+                            ->join('siswa', 'pengajaran.kelas', '=', 'siswa.kelas')
+                            ->whereColumn('siswa.id', 'penilaian.siswa_id')
+                            ->whereColumn('pengajaran.mapel_id', 'penilaian.mapel_id')
+                            ->where('pengajaran.guru_id', $guru->id);
+                    })->orWhereExists(function ($sub) use ($guru) {
+                        $sub->select(DB::raw(1))
+                            ->from('kelas')
+                            ->join('siswa as s', 'kelas.nama', '=', 's.kelas')
+                            ->whereColumn('s.id', 'penilaian.siswa_id')
+                            ->where('kelas.guru_id', $guru->id);
+                    });
                 });
             }
         }

--- a/tests/Feature/PenilaianSubjectVisibilityTest.php
+++ b/tests/Feature/PenilaianSubjectVisibilityTest.php
@@ -17,7 +17,84 @@ class PenilaianSubjectVisibilityTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_teacher_sees_only_own_subjects_in_penilaian_index(): void
+    public function test_non_homeroom_teacher_sees_only_own_subjects_in_penilaian_index(): void
+    {
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+
+        $guruUser1 = User::factory()->create(['role' => 'guru']);
+        $guru1 = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru 1',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+            'user_id' => $guruUser1->id,
+        ]);
+
+        $guruUser2 = User::factory()->create(['role' => 'guru']);
+        $guru2 = Guru::create([
+            'nuptk' => '2',
+            'nama' => 'Guru 2',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1990-01-01',
+            'user_id' => $guruUser2->id,
+        ]);
+
+        $kelas = Kelas::create([
+            'nama' => 'X-1',
+            'guru_id' => $guru1->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+
+        $siswa = Siswa::create([
+            'nama' => 'Siswa',
+            'nisn' => '123',
+            'kelas' => $kelas->nama,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2005-01-01',
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+
+        $mapel1 = MataPelajaran::create(['nama' => 'Matematika']);
+        $mapel2 = MataPelajaran::create(['nama' => 'IPA']);
+
+        Pengajaran::create(['guru_id' => $guru1->id, 'mapel_id' => $mapel1->id, 'kelas' => $kelas->nama]);
+        Pengajaran::create(['guru_id' => $guru2->id, 'mapel_id' => $mapel2->id, 'kelas' => $kelas->nama]);
+
+        Penilaian::create([
+            'siswa_id' => $siswa->id,
+            'mapel_id' => $mapel1->id,
+            'semester' => 1,
+            'hadir' => 10,
+            'sakit' => 0,
+            'izin' => 0,
+            'alpha' => 0,
+        ]);
+
+        Penilaian::create([
+            'siswa_id' => $siswa->id,
+            'mapel_id' => $mapel2->id,
+            'semester' => 1,
+            'hadir' => 10,
+            'sakit' => 0,
+            'izin' => 0,
+            'alpha' => 0,
+        ]);
+
+        $response = $this->actingAs($guruUser2)->get('/penilaian');
+
+        $response->assertOk();
+        $response->assertSee('IPA');
+        $response->assertDontSee('Matematika');
+    }
+
+    public function test_homeroom_teacher_sees_all_subjects_in_penilaian_index(): void
     {
         $ta = TahunAjaran::create([
             'nama' => '2024/2025',
@@ -91,6 +168,6 @@ class PenilaianSubjectVisibilityTest extends TestCase
 
         $response->assertOk();
         $response->assertSee('Matematika');
-        $response->assertDontSee('IPA');
+        $response->assertSee('IPA');
     }
 }


### PR DESCRIPTION
## Summary
- Let homeroom teachers see penilaian for all subjects in their class
- Add tests for homeroom vs non-homeroom teacher visibility

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_689635d08b44832b9a830a2db80f93a9