### PR TITLE
Merge consecutive schedule slots in student pages

### DIFF
--- a/app/Http/Controllers/AbsensiController.php
+++ b/app/Http/Controllers/AbsensiController.php
@@ -2,19 +2,19 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Absensi;
-use Illuminate\Http\Request;
-use App\Models\Siswa;
-use App\Models\Guru;
-use App\Models\Pengajaran;
-use App\Models\Kelas;
-use App\Models\Jadwal;
-use App\Models\MataPelajaran;
 use App\Exports\RekapAbsensiExport;
-use Maatwebsite\Excel\Facades\Excel;
+use App\Models\Absensi;
+use App\Models\Guru;
+use App\Models\Jadwal;
+use App\Models\Kelas;
+use App\Models\MataPelajaran;
+use App\Models\Pengajaran;
+use App\Models\Siswa;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
-use Carbon\Carbon;
+use Maatwebsite\Excel\Facades\Excel;
 
 class AbsensiController extends Controller
 {
@@ -26,9 +26,10 @@ class AbsensiController extends Controller
         }
 
         $guru = Guru::where('user_id', $user?->id)->first();
-        if (!$guru) {
+        if (! $guru) {
             return [];
         }
+
         return Pengajaran::where('guru_id', $guru->id)->pluck('kelas')->toArray();
     }
 
@@ -61,58 +62,61 @@ class AbsensiController extends Controller
         return view('absensi.index', compact('absensi', 'search'));
     }
 
-public function create()
-{
-    $siswa = Siswa::whereIn('kelas', $this->kelasGuru())->get();
-    $mapel = MataPelajaran::all();
-    return view('absensi.create', compact('siswa', 'mapel'));
-}
+    public function create()
+    {
+        $siswa = Siswa::whereIn('kelas', $this->kelasGuru())->get();
+        $mapel = MataPelajaran::all();
 
-public function store(Request $request)
-{
-    $data = $request->validate([
-        'siswa_id' => ['required', Rule::exists('siswa', 'id')->whereIn('kelas', $this->kelasGuru())],
-        'mapel_id' => 'required|exists:mata_pelajaran,id',
-        'tanggal' => 'required|date',
-        'status' => 'required|in:Hadir,Izin,Sakit,Alpha'
-    ]);
-    Absensi::create($data);
-
-    return redirect()->route('absensi.index')->with('success', 'Absensi berhasil ditambahkan');
-}
-
-public function edit(Absensi $absensi)
-{
-    if (!in_array($absensi->siswa->kelas, $this->kelasGuru())) {
-        abort(403);
+        return view('absensi.create', compact('siswa', 'mapel'));
     }
-    $siswa = Siswa::whereIn('kelas', $this->kelasGuru())->get();
-    $mapel = MataPelajaran::all();
-    return view('absensi.edit', compact('absensi', 'siswa', 'mapel'));
-}
 
-public function update(Request $request, Absensi $absensi)
-{
-    if (!in_array($absensi->siswa->kelas, $this->kelasGuru())) {
-        abort(403);
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'siswa_id' => ['required', Rule::exists('siswa', 'id')->whereIn('kelas', $this->kelasGuru())],
+            'mapel_id' => 'required|exists:mata_pelajaran,id',
+            'tanggal' => 'required|date',
+            'status' => 'required|in:Hadir,Izin,Sakit,Alpha',
+        ]);
+        Absensi::create($data);
+
+        return redirect()->route('absensi.index')->with('success', 'Absensi berhasil ditambahkan');
     }
-    $data = $request->validate([
-        'siswa_id' => ['required', Rule::exists('siswa', 'id')->whereIn('kelas', $this->kelasGuru())],
-        'mapel_id' => 'required|exists:mata_pelajaran,id',
-        'tanggal' => 'required|date',
-        'status' => 'required|in:Hadir,Izin,Sakit,Alpha'
-    ]);
-    $absensi->update($data);
 
-    return redirect()->route('absensi.index')->with('success', 'Absensi berhasil diupdate');
-}
+    public function edit(Absensi $absensi)
+    {
+        if (! in_array($absensi->siswa->kelas, $this->kelasGuru())) {
+            abort(403);
+        }
+        $siswa = Siswa::whereIn('kelas', $this->kelasGuru())->get();
+        $mapel = MataPelajaran::all();
+
+        return view('absensi.edit', compact('absensi', 'siswa', 'mapel'));
+    }
+
+    public function update(Request $request, Absensi $absensi)
+    {
+        if (! in_array($absensi->siswa->kelas, $this->kelasGuru())) {
+            abort(403);
+        }
+        $data = $request->validate([
+            'siswa_id' => ['required', Rule::exists('siswa', 'id')->whereIn('kelas', $this->kelasGuru())],
+            'mapel_id' => 'required|exists:mata_pelajaran,id',
+            'tanggal' => 'required|date',
+            'status' => 'required|in:Hadir,Izin,Sakit,Alpha',
+        ]);
+        $absensi->update($data);
+
+        return redirect()->route('absensi.index')->with('success', 'Absensi berhasil diupdate');
+    }
 
     public function destroy(Absensi $absensi)
     {
-        if (!in_array($absensi->siswa->kelas, $this->kelasGuru())) {
+        if (! in_array($absensi->siswa->kelas, $this->kelasGuru())) {
             abort(403);
         }
         $absensi->delete();
+
         return redirect()->route('absensi.index')->with('success', 'Absensi berhasil dihapus');
     }
 
@@ -130,23 +134,23 @@ public function update(Request $request, Absensi $absensi)
         $rekap = $siswaQuery->withCount([
             'absensi as hadir' => function ($q) use ($bulan, $tahun) {
                 $q->where('status', 'Hadir')
-                  ->whereMonth('tanggal', $bulan)
-                  ->whereYear('tanggal', $tahun);
+                    ->whereMonth('tanggal', $bulan)
+                    ->whereYear('tanggal', $tahun);
             },
             'absensi as izin' => function ($q) use ($bulan, $tahun) {
                 $q->where('status', 'Izin')
-                  ->whereMonth('tanggal', $bulan)
-                  ->whereYear('tanggal', $tahun);
+                    ->whereMonth('tanggal', $bulan)
+                    ->whereYear('tanggal', $tahun);
             },
             'absensi as sakit' => function ($q) use ($bulan, $tahun) {
                 $q->where('status', 'Sakit')
-                  ->whereMonth('tanggal', $bulan)
-                  ->whereYear('tanggal', $tahun);
+                    ->whereMonth('tanggal', $bulan)
+                    ->whereYear('tanggal', $tahun);
             },
             'absensi as alpha' => function ($q) use ($bulan, $tahun) {
                 $q->where('status', 'Alpha')
-                  ->whereMonth('tanggal', $bulan)
-                  ->whereYear('tanggal', $tahun);
+                    ->whereMonth('tanggal', $bulan)
+                    ->whereYear('tanggal', $tahun);
             },
         ])->get();
 
@@ -166,13 +170,12 @@ public function update(Request $request, Absensi $absensi)
         $bulan = $request->input('bulan', date('m'));
         $tahun = $request->input('tahun', date('Y'));
         $kelas = $request->input('kelas');
-        if ($kelas && !in_array($kelas, $this->kelasGuru())) {
+        if ($kelas && ! in_array($kelas, $this->kelasGuru())) {
             abort(403);
         }
 
         return Excel::download(new RekapAbsensiExport($bulan, $tahun, $kelas), 'rekap-absensi.xlsx');
     }
-
 
     public function pelajaran(Request $request)
     {
@@ -200,7 +203,9 @@ public function update(Request $request, Absensi $absensi)
                 $jadwalQuery->where('mapel_id', $request->mapel_id);
             }
 
-            $jadwal = $jadwalQuery->orderBy('jam_mulai')->get();
+            $jadwal = Jadwal::mergeConsecutive(
+                $jadwalQuery->orderBy('jam_mulai')->get()
+            );
             $kelasOptions = Kelas::all();
             $mapelOptions = MataPelajaran::all();
             $hariOptions = array_values($hariMap);
@@ -216,7 +221,7 @@ public function update(Request $request, Absensi $absensi)
         }
 
         $guru = Guru::where('user_id', Auth::id())->first();
-        if (!$guru) {
+        if (! $guru) {
             $jadwal = collect();
         } else {
             $jadwal = Jadwal::with(['mapel', 'kelas'])
@@ -224,10 +229,11 @@ public function update(Request $request, Absensi $absensi)
                 ->orderByRaw("CASE hari WHEN 'Senin' THEN 1 WHEN 'Selasa' THEN 2 WHEN 'Rabu' THEN 3 WHEN 'Kamis' THEN 4 WHEN 'Jumat' THEN 5 WHEN 'Sabtu' THEN 6 ELSE 7 END")
                 ->orderBy('jam_mulai')
                 ->get()
-                ->groupBy('hari');
+                ->groupBy('hari')
+                ->map(fn ($items) => Jadwal::mergeConsecutive($items));
         }
 
-        $days = ['Senin','Selasa','Rabu','Kamis','Jumat'];
+        $days = ['Senin', 'Selasa', 'Rabu', 'Kamis', 'Jumat'];
         $startOfWeek = Carbon::now()->startOfWeek();
         $dates = [];
         foreach ($days as $index => $day) {
@@ -252,10 +258,10 @@ public function update(Request $request, Absensi $absensi)
         $kelasNama = $jadwal->kelas->nama;
         $siswa = Siswa::where('kelas', $kelasNama)->get();
         $absen = Absensi::whereIn('siswa_id', $siswa->pluck('id'))
-                    ->where('mapel_id', $jadwal->mapel_id)
-                    ->where('tanggal', $tanggal)
-                    ->get()
-                    ->pluck('status', 'siswa_id');
+            ->where('mapel_id', $jadwal->mapel_id)
+            ->where('tanggal', $tanggal)
+            ->get()
+            ->pluck('status', 'siswa_id');
 
         return view('absensi.pelajaran_form', [
             'jadwal' => $jadwal,
@@ -290,6 +296,6 @@ public function update(Request $request, Absensi $absensi)
         }
 
         return redirect()->route('absensi.pelajaran.form', [$jadwal->id, 'tanggal' => $tanggal])
-                         ->with('success', 'Absensi berhasil disimpan');
+            ->with('success', 'Absensi berhasil disimpan');
     }
 }

--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -59,7 +59,8 @@ class StudentController extends Controller
                 ->where('kelas_id', $kelas->id)
                 ->orderBy('jam_mulai')
                 ->get()
-                ->groupBy('hari');
+                ->groupBy('hari')
+                ->map(fn ($items) => Jadwal::mergeConsecutive($items));
         } else {
             $jadwal = collect();
         }

--- a/app/Models/Jadwal.php
+++ b/app/Models/Jadwal.php
@@ -26,4 +26,26 @@ class Jadwal extends Model
     {
         return $this->belongsTo(Guru::class);
     }
+
+    public static function mergeConsecutive($jadwal)
+    {
+        $merged = collect();
+        foreach ($jadwal as $item) {
+            if ($merged->isNotEmpty()) {
+                $last = $merged->last();
+                if (
+                    $last->kelas_id === $item->kelas_id &&
+                    $last->mapel_id === $item->mapel_id &&
+                    $last->guru_id === $item->guru_id &&
+                    $last->jam_selesai === $item->jam_mulai
+                ) {
+                    $last->jam_selesai = $item->jam_selesai;
+                    continue;
+                }
+            }
+            $merged->push(clone $item);
+        }
+
+        return $merged;
+    }
 }

--- a/tests/Feature/AbsensiPelajaranMergeTest.php
+++ b/tests/Feature/AbsensiPelajaranMergeTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Guru;
+use App\Models\Jadwal;
+use App\Models\Kelas;
+use App\Models\MataPelajaran;
+use App\Models\TahunAjaran;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AbsensiPelajaranMergeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_consecutive_slots_are_merged_in_attendance_menu(): void
+    {
+        Carbon::setTestNow('2024-07-01 07:30:00');
+
+        $user = User::factory()->create(['role' => 'guru']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+            'user_id' => $user->id,
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'Matematika']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+
+        $first = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+        $second = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '08:00',
+            'jam_selesai' => '09:00',
+        ]);
+
+        $response = $this->actingAs($user)->get('/absensi/pelajaran');
+
+        $response->assertOk();
+        $response->assertSee('07:00 - 09:00');
+        $response->assertSee(route('absensi.pelajaran.form', ['jadwal' => $first->id, 'tanggal' => '2024-07-01']));
+        $response->assertDontSee(route('absensi.pelajaran.form', ['jadwal' => $second->id, 'tanggal' => '2024-07-01']));
+    }
+}

--- a/tests/Feature/StudentScheduleMergeTest.php
+++ b/tests/Feature/StudentScheduleMergeTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\Siswa;
+use App\Models\Jadwal;
+use App\Models\TahunAjaran;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StudentScheduleMergeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_consecutive_slots_are_merged_in_student_schedule(): void
+    {
+        Carbon::setTestNow('2024-07-01 07:30:00');
+
+        $user = User::factory()->create(['role' => 'siswa']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'Matematika']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        Siswa::create([
+            'nama' => 'Siswa 1',
+            'nisn' => '123',
+            'kelas' => $kelas->nama,
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+            'user_id' => $user->id,
+        ]);
+
+        $first = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+        $second = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '08:00',
+            'jam_selesai' => '09:00',
+        ]);
+
+        $response = $this->actingAs($user)->get('/saya/jadwal');
+
+        $response->assertOk();
+        $response->assertSee('07:00 - 09:00');
+        $response->assertSee(route('student.jadwal.absen.form', $first->id));
+        $response->assertDontSee(route('student.jadwal.absen.form', $second->id));
+    }
+}
+


### PR DESCRIPTION
## Summary
- extract `Jadwal::mergeConsecutive` helper for merging back-to-back schedule entries
- apply merging on student schedule page to show single session per consecutive slot
- reuse merge helper in attendance controller and add regression test

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_689638b0b978832bb5e018c6a5695c44