### PR TITLE
Disable attendance link for future lessons

### DIFF
--- a/resources/views/absensi/pelajaran.blade.php
+++ b/resources/views/absensi/pelajaran.blade.php
@@ -57,13 +57,22 @@
     @endforelse
 </ul>
 @else
+    @php $now = \Carbon\Carbon::now(); @endphp
     @foreach($days as $day)
         <h4 class="mt-4">{{ $day }}</h4>
         <ul class="list-group mb-3">
             @forelse($jadwal->get($day, collect()) as $j)
+                @php
+                    $start = \Carbon\Carbon::parse($dates[$day] . ' ' . $j->jam_mulai);
+                    $end = \Carbon\Carbon::parse($dates[$day] . ' ' . $j->jam_selesai);
+                @endphp
                 <li class="list-group-item d-flex justify-content-between align-items-center">
                     <span>{{ $j->kelas->nama }} - {{ $j->mapel->nama }} ({{ $j->jam_mulai }} - {{ $j->jam_selesai }})</span>
-                    <a href="{{ route('absensi.pelajaran.form', ['jadwal' => $j->id, 'tanggal' => $dates[$day]]) }}" class="btn btn-sm btn-primary">Isi Absen</a>
+                    @if($now->between($start, $end))
+                        <a href="{{ route('absensi.pelajaran.form', ['jadwal' => $j->id, 'tanggal' => $dates[$day]]) }}" class="btn btn-sm btn-primary">Isi Absen</a>
+                    @else
+                        <button class="btn btn-sm btn-primary" disabled>Isi Absen</button>
+                    @endif
                 </li>
             @empty
                 <li class="list-group-item text-center">Tidak ada jadwal</li>

--- a/tests/Feature/GuruScheduleFutureButtonTest.php
+++ b/tests/Feature/GuruScheduleFutureButtonTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\Jadwal;
+use App\Models\TahunAjaran;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Carbon\Carbon;
+
+class GuruScheduleFutureButtonTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_future_schedule_button_disabled(): void
+    {
+        Carbon::setTestNow('2024-07-01 08:00:00'); // Monday
+
+        $user = User::factory()->create(['role' => 'guru']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+            'user_id' => $user->id,
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+
+        // Schedule later today
+        $future = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '09:00',
+            'jam_selesai' => '10:00',
+        ]);
+
+        $response = $this->actingAs($user)->get('/absensi/pelajaran');
+
+        $response->assertOk();
+        $response->assertSee('<button class="btn btn-sm btn-primary" disabled>Isi Absen</button>', false);
+        $response->assertDontSee(route('absensi.pelajaran.form', ['jadwal' => $future->id, 'tanggal' => '2024-07-01']));
+    }
+}


### PR DESCRIPTION
## Summary
- Only allow filling attendance during scheduled lesson times
- Add feature test for guru schedules

## Testing
- `./vendor/bin/phpunit tests/Feature/GuruScheduleFutureButtonTest.php`
- `./vendor/bin/phpunit tests/Feature/AbsensiPelajaranMergeTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68964b16dd3c832bb96bfbc6af7d15e1