### PR TITLE
Disallow future attendance entries

### DIFF
--- a/app/Http/Controllers/AbsensiController.php
+++ b/app/Http/Controllers/AbsensiController.php
@@ -189,7 +189,10 @@ class AbsensiController extends Controller
             'Sunday' => 'Minggu',
         ];
 
-        $tanggal = $request->input('tanggal', date('Y-m-d'));
+        $tanggal = $request->input('tanggal', Carbon::now()->toDateString());
+        if (Carbon::parse($tanggal)->isFuture()) {
+            abort(403);
+        }
         $hari = $request->input('hari', $hariMap[date('l', strtotime($tanggal))]);
 
         if (Auth::user()->role === 'admin') {
@@ -275,7 +278,10 @@ class AbsensiController extends Controller
             abort(403);
         }
 
-        $tanggal = $request->input('tanggal', date('Y-m-d'));
+        $tanggal = $request->input('tanggal', Carbon::now()->toDateString());
+        if (Carbon::parse($tanggal)->isFuture()) {
+            abort(403);
+        }
         $kelasNama = $jadwal->kelas->nama;
         $siswa = Siswa::where('kelas', $kelasNama)->get();
         $absen = Absensi::whereIn('siswa_id', $siswa->pluck('id'))
@@ -300,11 +306,11 @@ class AbsensiController extends Controller
         }
 
         $request->validate([
-            'tanggal' => 'required|date',
+            'tanggal' => 'required|date|before_or_equal:today',
             'status' => 'array',
         ]);
 
-        $tanggal = $request->input('tanggal', date('Y-m-d'));
+        $tanggal = $request->input('tanggal', Carbon::now()->toDateString());
         $siswaIds = Siswa::where('kelas', $jadwal->kelas->nama)->pluck('id');
         $statusData = $request->input('status', []);
         foreach ($siswaIds as $id) {

--- a/resources/views/absensi/pelajaran_form.blade.php
+++ b/resources/views/absensi/pelajaran_form.blade.php
@@ -18,7 +18,7 @@
 @endif
 <form method="GET" class="row g-2 mb-3">
     <div class="col-auto">
-        <input type="date" name="tanggal" value="{{ $tanggal }}" class="form-control" onchange="this.form.submit()">
+        <input type="date" name="tanggal" value="{{ $tanggal }}" class="form-control" max="{{ now()->toDateString() }}" onchange="this.form.submit()">
     </div>
     <noscript class="col-auto"><button class="btn btn-primary">Tampilkan</button></noscript>
 </form>

--- a/tests/Feature/GuruAbsensiFutureDateTest.php
+++ b/tests/Feature/GuruAbsensiFutureDateTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\TahunAjaran;
+use App\Models\Jadwal;
+use App\Models\Siswa;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GuruAbsensiFutureDateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setupData()
+    {
+        $user = User::factory()->create(['role' => 'guru']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+            'user_id' => $user->id,
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        $siswa = Siswa::create([
+            'nama' => 'Siswa 1',
+            'nisn' => '123',
+            'kelas' => $kelas->nama,
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+        ]);
+        $jadwal = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+
+        return [$user, $siswa, $jadwal];
+    }
+
+    public function test_guru_cannot_store_absensi_for_future_date(): void
+    {
+        Carbon::setTestNow('2024-07-01 08:00:00');
+
+        [$user, $siswa, $jadwal] = $this->setupData();
+
+        $this->actingAs($user)
+            ->post('/absensi/pelajaran/'.$jadwal->id, [
+                'tanggal' => '2024-07-02',
+                'status' => [$siswa->id => 'Hadir'],
+            ])
+            ->assertSessionHasErrors('tanggal');
+
+        $this->assertDatabaseMissing('absensi', [
+            'siswa_id' => $siswa->id,
+            'tanggal' => '2024-07-02',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Prevent teachers from opening attendance forms for future dates.
- Block saving attendance records with a future date and limit date picker to today.
- Add regression test ensuring future-date submissions are rejected.

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68964e889b9c832b923f877b85557b47