### PR TITLE
Disable attendance actions for future dates

### DIFF
--- a/resources/views/absensi/pelajaran.blade.php
+++ b/resources/views/absensi/pelajaran.blade.php
@@ -46,7 +46,7 @@
 @endif
 
 @if(Auth::user()->role === 'admin')
-@php $isFuture = \Carbon\Carbon::parse($tanggal)->isFuture(); @endphp
+@php $isFuture = \Carbon\Carbon::parse($tanggal)->isAfter(\Carbon\Carbon::today()); @endphp
 <ul class="list-group">
     @forelse($jadwal as $j)
         <li class="list-group-item d-flex justify-content-between align-items-center">

--- a/resources/views/absensi/pelajaran_form.blade.php
+++ b/resources/views/absensi/pelajaran_form.blade.php
@@ -49,6 +49,6 @@
         </tbody>
     </table>
 </div>
-    <button class="btn btn-success" @if($isFuture) disabled @endif>Simpan</button>
+    <button class="btn btn-success" @disabled($isFuture)>Simpan</button>
 </form>
 @endsection

--- a/tests/Feature/FutureAttendanceAccessTest.php
+++ b/tests/Feature/FutureAttendanceAccessTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\Jadwal;
+use App\Models\TahunAjaran;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FutureAttendanceAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_schedule_shows_disabled_link_for_future_date(): void
+    {
+        Carbon::setTestNow('2024-07-01 07:00:00');
+
+        $admin = User::factory()->create(['role' => 'admin']);
+        $guruUser = User::factory()->create(['role' => 'guru']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+            'user_id' => $guruUser->id,
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'Matematika']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        $jadwal = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Selasa',
+            'jam_mulai' => '09:00',
+            'jam_selesai' => '10:00',
+        ]);
+
+        $response = $this->actingAs($admin)->get('/absensi/pelajaran?tanggal=2024-07-02&hari=Selasa');
+
+        $response->assertOk();
+        $response->assertSee('<button class="btn btn-sm btn-primary" disabled>Isi Absen</button>', false);
+        $response->assertDontSee(route('absensi.pelajaran.form', ['jadwal' => $jadwal->id, 'tanggal' => '2024-07-02']));
+    }
+
+    public function test_future_date_disables_save_button_on_attendance_form(): void
+    {
+        Carbon::setTestNow('2024-07-01 07:00:00');
+
+        $user = User::factory()->create(['role' => 'guru']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+            'user_id' => $user->id,
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'Matematika']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        $jadwal = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+
+        $response = $this->actingAs($user)->get(route('absensi.pelajaran.form', ['jadwal' => $jadwal->id, 'tanggal' => '2024-07-02']));
+
+        $response->assertOk();
+        $response->assertSee('<button class="btn btn-success" disabled>Simpan</button>', false);
+    }
+}
+

--- a/tests/Feature/GuruAbsensiFutureDateTest.php
+++ b/tests/Feature/GuruAbsensiFutureDateTest.php
@@ -89,6 +89,6 @@ class GuruAbsensiFutureDateTest extends TestCase
             ->get('/absensi/pelajaran/'.$jadwal->id.'?tanggal=2024-07-02')
             ->assertStatus(200);
 
-        $response->assertSee('<button class="btn btn-success"  disabled', false);
+        $response->assertSee('<button class="btn btn-success" disabled', false);
     }
 }


### PR DESCRIPTION
## Summary
- Prevent admins from opening future attendance forms by disabling the "Isi Absen" link when a chosen schedule date is beyond today
- Guard attendance records by disabling the "Simpan" button if a future date is selected
- Add feature tests validating disabled links and buttons for future dates

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689655b07600832bac4b3f9cbe443707