### PR TITLE
Handle single-slot scheduling in timetable generation

### DIFF
--- a/app/Http/Controllers/JadwalController.php
+++ b/app/Http/Controllers/JadwalController.php
@@ -253,7 +253,38 @@ class JadwalController extends Controller
                         }
                     }
 
-                    if (count($created) >= $requiredSlots) {
+                    if (count($created) < $requiredSlots) {
+                        foreach ($dayOrder as $day) {
+                            $slotOrder = $slots;
+                            shuffle($slotOrder);
+                            foreach ($slotOrder as $slot) {
+                                if (count($created) >= $requiredSlots) {
+                                    break 2;
+                                }
+
+                                if ($dayCounts[$day] >= 2) {
+                                    continue;
+                                }
+
+                                if ($this->hasConflict($teacherSchedules[$pengajaran->guru_id][$day], $slot) ||
+                                    $this->hasConflict($classSchedules[$kelas->id][$day], $slot)) {
+                                    continue;
+                                }
+
+                                $created[] = [
+                                    'kelas_id' => $kelas->id,
+                                    'mapel_id' => $pengajaran->mapel_id,
+                                    'guru_id' => $pengajaran->guru_id,
+                                    'hari' => $day,
+                                    'jam_mulai' => $slot[0],
+                                    'jam_selesai' => $slot[1],
+                                ];
+                                $dayCounts[$day] += 1;
+                            }
+                        }
+                    }
+
+                    if (count($created) > 0) {
                         foreach ($created as $data) {
                             Jadwal::create($data);
                             $this->syncPengajaran($data);


### PR DESCRIPTION
## Summary
- Allow `JadwalController::generate` to assign a single slot when no slot pairs are available
- Ensure generated single slot still syncs `Pengajaran`
- Test that a lone 09:00–10:00 slot is filled when it is the only available time

## Testing
- `./vendor/bin/phpunit tests/Feature/JadwalGenerateTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68965aa2725c832b8468bfd8c0475817