### PR TITLE
Add password-protected attendance sessions

### DIFF
--- a/app/Models/AttendanceSession.php
+++ b/app/Models/AttendanceSession.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AttendanceSession extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'jadwal_id',
+        'tanggal',
+        'password',
+        'opened_at',
+        'closed_at',
+    ];
+
+    public function jadwal()
+    {
+        return $this->belongsTo(Jadwal::class);
+    }
+}

--- a/database/migrations/2025_07_10_000002_create_attendance_sessions_table.php
+++ b/database/migrations/2025_07_10_000002_create_attendance_sessions_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('attendance_sessions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('jadwal_id')->constrained('jadwal')->cascadeOnDelete();
+            $table->date('tanggal');
+            $table->string('password');
+            $table->timestamp('opened_at');
+            $table->timestamp('closed_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('attendance_sessions');
+    }
+};

--- a/resources/views/absensi/pelajaran_form.blade.php
+++ b/resources/views/absensi/pelajaran_form.blade.php
@@ -22,6 +22,24 @@
     </div>
     <noscript class="col-auto"><button class="btn btn-primary">Tampilkan</button></noscript>
 </form>
+@if($activeSession)
+<div class="mb-3">
+    <div class="alert alert-info">Password Sesi: {{ $activeSession->password }}</div>
+    <form action="{{ route('absensi.pelajaran.close', $jadwal->id) }}" method="POST" class="d-inline">
+        @csrf
+        <input type="hidden" name="tanggal" value="{{ $tanggal }}">
+        <button class="btn btn-warning">Tutup Sesi</button>
+    </form>
+</div>
+@else
+<div class="mb-3">
+    <form action="{{ route('absensi.pelajaran.open', $jadwal->id) }}" method="POST" class="d-inline">
+        @csrf
+        <input type="hidden" name="tanggal" value="{{ $tanggal }}">
+        <button class="btn btn-primary">Buka Sesi</button>
+    </form>
+</div>
+@endif
 <form action="{{ route('absensi.pelajaran.store', $jadwal->id) }}" method="POST">
     @csrf
     <input type="hidden" name="tanggal" value="{{ $tanggal }}">

--- a/resources/views/siswa/absen_jadwal.blade.php
+++ b/resources/views/siswa/absen_jadwal.blade.php
@@ -50,6 +50,11 @@
         </select>
         <x-input-error :messages="$errors->get('status')" class="mt-1" />
     </div>
+    <div class="mb-3">
+        <label>Password Sesi</label>
+        <input type="text" name="password" class="form-control" required>
+        <x-input-error :messages="$errors->get('password')" class="mt-1" />
+    </div>
     <button class="btn btn-success">Simpan</button>
     <a href="{{ route('student.jadwal') }}" class="btn btn-secondary">Kembali</a>
 </form>

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,6 +48,8 @@ Route::middleware(['auth', 'role:admin,guru'])->group(function () {
     Route::get('/absensi/pelajaran', [AbsensiController::class, 'pelajaran'])->name('absensi.pelajaran');
     Route::get('/absensi/pelajaran/{jadwal}', [AbsensiController::class, 'pelajaranForm'])->name('absensi.pelajaran.form');
     Route::post('/absensi/pelajaran/{jadwal}', [AbsensiController::class, 'pelajaranStore'])->name('absensi.pelajaran.store');
+    Route::post('/absensi/pelajaran/{jadwal}/open', [AbsensiController::class, 'openSession'])->name('absensi.pelajaran.open');
+    Route::post('/absensi/pelajaran/{jadwal}/close', [AbsensiController::class, 'closeSession'])->name('absensi.pelajaran.close');
     Route::get('/absensi/rekap', [AbsensiController::class, 'rekap'])->name('absensi.rekap');
     Route::get('/absensi/rekap/export', [AbsensiController::class, 'exportRekap'])->name('absensi.rekap.export');
 });

--- a/tests/Feature/StudentScheduleAbsensiListTest.php
+++ b/tests/Feature/StudentScheduleAbsensiListTest.php
@@ -11,6 +11,7 @@ use App\Models\Jadwal;
 use App\Models\TahunAjaran;
 use Carbon\Carbon;
 use App\Models\Absensi;
+use App\Models\AttendanceSession;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -60,17 +61,24 @@ class StudentScheduleAbsensiListTest extends TestCase
             'jam_selesai' => '08:00',
         ]);
 
+        AttendanceSession::create([
+            'jadwal_id' => $jadwal->id,
+            'tanggal' => now()->toDateString(),
+            'password' => '123456',
+            'opened_at' => now(),
+        ]);
+
         Absensi::create([
             'siswa_id' => $siswa->id,
             'mapel_id' => $mapel->id,
-            'tanggal' => date('Y-m-d', strtotime('-1 day')),
+            'tanggal' => now()->subDay()->toDateString(),
             'status' => 'Hadir',
         ]);
 
         $response = $this->actingAs($user)->get('/saya/jadwal/'.$jadwal->id.'/absen');
 
         $response->assertOk();
-        $response->assertSee(date('Y-m-d', strtotime('-1 day')));
+        $response->assertSee(now()->subDay()->toDateString());
         $response->assertSee('Hadir');
     }
 }

--- a/tests/Feature/StudentScheduleAbsensiTest.php
+++ b/tests/Feature/StudentScheduleAbsensiTest.php
@@ -9,6 +9,7 @@ use App\Models\Kelas;
 use App\Models\Siswa;
 use App\Models\Jadwal;
 use App\Models\TahunAjaran;
+use App\Models\AttendanceSession;
 use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -59,9 +60,17 @@ class StudentScheduleAbsensiTest extends TestCase
             'jam_selesai' => '08:00',
         ]);
 
+        AttendanceSession::create([
+            'jadwal_id' => $jadwal->id,
+            'tanggal' => now()->toDateString(),
+            'password' => '123456',
+            'opened_at' => now(),
+        ]);
+
         $this->actingAs($user)
             ->post('/saya/jadwal/'.$jadwal->id.'/absen', [
                 'status' => 'Hadir',
+                'password' => '123456',
             ])
             ->assertRedirect('/saya/jadwal');
 
@@ -69,7 +78,7 @@ class StudentScheduleAbsensiTest extends TestCase
             'siswa_id' => $siswa->id,
             'mapel_id' => $mapel->id,
             'status' => 'Hadir',
-            'tanggal' => date('Y-m-d'),
+            'tanggal' => now()->toDateString(),
         ]);
     }
 
@@ -117,6 +126,171 @@ class StudentScheduleAbsensiTest extends TestCase
 
         $this->actingAs($user)
             ->get('/saya/jadwal/'.$jadwal->id.'/absen')
+            ->assertForbidden();
+    }
+
+    public function test_student_cannot_absen_before_session_open(): void
+    {
+        Carbon::setTestNow('2024-07-01 07:30:00');
+
+        $user = User::factory()->create(['role' => 'siswa']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        Siswa::create([
+            'nama' => 'Siswa 1',
+            'nisn' => '123',
+            'kelas' => $kelas->nama,
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+            'user_id' => $user->id,
+        ]);
+        $jadwal = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+
+        $this->actingAs($user)
+            ->post('/saya/jadwal/'.$jadwal->id.'/absen', [
+                'status' => 'Hadir',
+                'password' => '000000',
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_student_must_provide_correct_password(): void
+    {
+        Carbon::setTestNow('2024-07-01 07:30:00');
+
+        $user = User::factory()->create(['role' => 'siswa']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        Siswa::create([
+            'nama' => 'Siswa 1',
+            'nisn' => '123',
+            'kelas' => $kelas->nama,
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+            'user_id' => $user->id,
+        ]);
+        $jadwal = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+
+        AttendanceSession::create([
+            'jadwal_id' => $jadwal->id,
+            'tanggal' => now()->toDateString(),
+            'password' => '123456',
+            'opened_at' => now(),
+        ]);
+
+        $this->actingAs($user)
+            ->post('/saya/jadwal/'.$jadwal->id.'/absen', [
+                'status' => 'Hadir',
+                'password' => '000000',
+            ])
+            ->assertForbidden();
+    }
+
+    public function test_session_invalid_after_closed(): void
+    {
+        Carbon::setTestNow('2024-07-01 07:30:00');
+
+        $user = User::factory()->create(['role' => 'siswa']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        Siswa::create([
+            'nama' => 'Siswa 1',
+            'nisn' => '123',
+            'kelas' => $kelas->nama,
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+            'user_id' => $user->id,
+        ]);
+        $jadwal = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+
+        AttendanceSession::create([
+            'jadwal_id' => $jadwal->id,
+            'tanggal' => now()->toDateString(),
+            'password' => '123456',
+            'opened_at' => now()->subMinutes(10),
+            'closed_at' => now()->subMinute(),
+        ]);
+
+        $this->actingAs($user)
+            ->post('/saya/jadwal/'.$jadwal->id.'/absen', [
+                'status' => 'Hadir',
+                'password' => '123456',
+            ])
             ->assertForbidden();
     }
 }


### PR DESCRIPTION
## Summary
- create `attendance_sessions` table and model
- allow teachers to open/close sessions and view generated passwords
- require students to provide session password when taking attendance and cover with tests

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_689661073308832ba3665472439e158d