### PR TITLE
Handle schedule attendance errors with redirects

### DIFF
--- a/resources/views/siswa/absen_jadwal.blade.php
+++ b/resources/views/siswa/absen_jadwal.blade.php
@@ -7,6 +7,9 @@
 @if(session('success'))
     <div class="alert alert-success">{{ session('success') }}</div>
 @endif
+@if(session('error'))
+    <div class="alert alert-danger">{{ session('error') }}</div>
+@endif
 @if($errors->any())
     <div class="alert alert-danger">
         <ul class="mb-0">
@@ -48,12 +51,16 @@
             <option value="Sakit">Sakit</option>
             <option value="Alpha">Alpha</option>
         </select>
-        <x-input-error :messages="$errors->get('status')" class="mt-1" />
+        @error('status')
+            <div class="text-danger">{{ $message }}</div>
+        @enderror
     </div>
     <div class="mb-3">
         <label>Password Sesi</label>
         <input type="text" name="password" class="form-control" required>
-        <x-input-error :messages="$errors->get('password')" class="mt-1" />
+        @error('password')
+            <div class="text-danger">{{ $message }}</div>
+        @enderror
     </div>
     <button class="btn btn-success">Simpan</button>
     <a href="{{ route('student.jadwal') }}" class="btn btn-secondary">Kembali</a>


### PR DESCRIPTION
## Summary
- Redirect back with error messages when attendance time invalid or session closed
- Validate password using Validator and surface errors in the attendance form
- Show session and field-specific error messages in student schedule attendance view

## Testing
- `php artisan test` *(fails: Tests\Feature\StudentScheduleAbsensiTest\: student cannot access absen form after end time, student cannot absen before session open, student must provide correct password, session invalid after closed)*

------
https://chatgpt.com/codex/tasks/task_e_689668f23c8c832bb9f8b50b4336aefc