### PR TITLE
Redirect to session form after open/close

### DIFF
--- a/app/Http/Controllers/AbsensiController.php
+++ b/app/Http/Controllers/AbsensiController.php
@@ -260,7 +260,8 @@ class AbsensiController extends Controller
             'opened_at' => now(),
         ]);
 
-        return back()->with('session_password', $password);
+        return redirect()->route('absensi.pelajaran.form', ['jadwal' => $jadwal->id, 'tanggal' => $tanggal])
+            ->with('session_password', $password);
     }
 
     public function closeSession(Request $request, Jadwal $jadwal)
@@ -275,7 +276,8 @@ class AbsensiController extends Controller
             $session->update(['closed_at' => now()]);
         }
 
-        return back()->with('success', 'Sesi ditutup');
+        return redirect()->route('absensi.pelajaran.form', ['jadwal' => $jadwal->id, 'tanggal' => $tanggal])
+            ->with('success', 'Sesi ditutup');
     }
 
     private function mergeConsecutiveJadwal($jadwal)


### PR DESCRIPTION
## Summary
- Redirect to absensi pelajaran form after opening an attendance session and pass password
- Redirect to the form after closing a session

## Testing
- `php artisan test` *(fails: Expected response status code [403] but received 302)*

------
https://chatgpt.com/codex/tasks/task_e_68966d17ef70832bb0ed401d40f6892c