### PR TITLE
Display parent and homeroom teacher names on report card

### DIFF
--- a/app/Http/Controllers/RaporController.php
+++ b/app/Http/Controllers/RaporController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\Request;
 use App\Models\Siswa;
 use App\Models\Penilaian;
 use App\Models\Absensi;
+use App\Models\Kelas;
 
 class RaporController extends Controller
 {
@@ -30,11 +31,17 @@ class RaporController extends Controller
             ->groupBy('status')
             ->pluck('jumlah', 'status');
 
+        $waliKelas = Kelas::with('waliKelas')
+            ->where('nama', $siswa->kelas)
+            ->first()
+            ->waliKelas->nama ?? '';
+
         $pdf = Pdf::loadView('rapor', [
             'siswa' => $siswa,
             'penilaian' => $penilaian,
             'semester' => $semester,
             'ketidakhadiran' => $ketidakhadiran,
+            'waliKelas' => $waliKelas,
         ])->setPaper('a4', 'portrait');
 
         return $pdf->download('rapor.pdf');

--- a/resources/views/rapor.blade.php
+++ b/resources/views/rapor.blade.php
@@ -77,8 +77,8 @@
             <td style="text-align:center">Wali Kelas</td>
         </tr>
         <tr>
-            <td style="padding-top:60px;text-align:center">__________________</td>
-            <td style="padding-top:60px;text-align:center">__________________</td>
+            <td style="padding-top:60px;text-align:center">__________________<br>{{ $siswa->nama_ortu }}</td>
+            <td style="padding-top:60px;text-align:center">__________________<br>{{ $waliKelas }}</td>
         </tr>
     </table>
 


### PR DESCRIPTION
## Summary
- Show parent and homeroom teacher names beneath signature lines in the report card PDF
- Fetch homeroom teacher name based on student's class when generating the report

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6896e1e283e4832b822253a9fc3ac71e