### PR TITLE
Add seeder for principal (Kepala Sekolah)

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,6 +18,7 @@ class DatabaseSeeder extends Seeder
             AdminSeeder::class,
             UserSeeder::class,
             GuruSeeder::class,
+            KepalaSekolahSeeder::class,
             TahunAjaranSeeder::class,
             SiswaSeeder::class,
             MataPelajaranSeeder::class,

--- a/database/seeders/KepalaSekolahSeeder.php
+++ b/database/seeders/KepalaSekolahSeeder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use App\Models\User;
+
+class KepalaSekolahSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $user = User::updateOrCreate(
+            ['email' => 'kepsek@demo.com'],
+            [
+                'name' => 'Kepala Sekolah',
+                'password' => Hash::make('password'),
+                'role' => 'kepala_sekolah',
+            ]
+        );
+
+        DB::table('guru')->updateOrInsert(
+            ['nuptk' => '1234567890123456'],
+            [
+                'nama' => 'Kepala Sekolah',
+                'email' => 'kepsek@demo.com',
+                'tempat_lahir' => 'Jakarta',
+                'jenis_kelamin' => 'L',
+                'tanggal_lahir' => '1970-01-01',
+                'user_id' => $user->id,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add KepalaSekolahSeeder to create a principal user and matching guru entry
- register KepalaSekolahSeeder in DatabaseSeeder

## Testing
- `php artisan migrate --force`
- `php artisan db:seed --class=KepalaSekolahSeeder`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6896e8615448832ba483b1c180505725