### PR TITLE
Handle optional headmaster in report generation

### DIFF
--- a/app/Http/Controllers/RaporController.php
+++ b/app/Http/Controllers/RaporController.php
@@ -9,6 +9,7 @@ use App\Models\Siswa;
 use App\Models\Penilaian;
 use App\Models\Absensi;
 use App\Models\Kelas;
+use App\Models\Guru;
 
 class RaporController extends Controller
 {
@@ -36,6 +37,11 @@ class RaporController extends Controller
             ->first();
         $waliKelas = $kelas->waliKelas ?? null;
 
+        $kepalaSekolah = Guru::where('role', 'kepala_sekolah')->first();
+        if ($kepalaSekolah === null) {
+            $kepalaSekolah = null;
+        }
+
         $pdf = Pdf::loadView('rapor', [
             'siswa' => $siswa,
             'penilaian' => $penilaian,
@@ -43,6 +49,7 @@ class RaporController extends Controller
             'ketidakhadiran' => $ketidakhadiran,
             'waliKelas' => $waliKelas->nama ?? '',
             'waliKelasNuptk' => $waliKelas->nuptk ?? '',
+            'kepalaSekolah' => $kepalaSekolah,
         ])->setPaper('a4', 'portrait');
 
         return $pdf->download('rapor.pdf');

--- a/resources/views/rapor.blade.php
+++ b/resources/views/rapor.blade.php
@@ -75,10 +75,18 @@
         <tr>
             <td style="text-align:center">Orang Tua/Wali</td>
             <td style="text-align:center">Wali Kelas</td>
+            <td style="text-align:center">Kepala Sekolah</td>
         </tr>
         <tr>
             <td style="padding-top:60px;text-align:center">__________________<br>{{ $siswa->nama_ortu }}</td>
             <td style="padding-top:60px;text-align:center">__________________<br>{{ $waliKelas }}<br>NUPTK: {{ $waliKelasNuptk }}</td>
+            <td style="padding-top:60px;text-align:center">__________________<br>
+                @if($kepalaSekolah)
+                    {{ $kepalaSekolah->nama }}<br>NIP: {{ $kepalaSekolah->nuptk }}
+                @else
+                    Nama Kepala Sekolah<br>NIP: -
+                @endif
+            </td>
         </tr>
     </table>
 


### PR DESCRIPTION
## Summary
- Allow report generation to proceed when headmaster data is absent
- Display headmaster name and NIP in report when available, otherwise show placeholders

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6896ed6cb0c8832bb7b3a22ff16bfc66