### PR TITLE
Remove add button from Penilaian index page

### DIFF
--- a/resources/views/penilaian/index.blade.php
+++ b/resources/views/penilaian/index.blade.php
@@ -19,7 +19,6 @@
         <a href="{{ route('penilaian.index') }}" class="btn btn-secondary">Reset</a>
     </div>
 </form>
-<a href="{{ route('penilaian.create') }}" class="btn btn-primary mb-3">Tambah</a>
 <div class="table-responsive">
 <table class="table table-bordered">
     <thead>


### PR DESCRIPTION
## Summary
- remove "Tambah" button from Penilaian data listing

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_6896f066d1ac832b944737b501b4842c