### PR TITLE
Remove day filter from attendance schedule

### DIFF
--- a/app/Http/Controllers/AbsensiController.php
+++ b/app/Http/Controllers/AbsensiController.php
@@ -190,7 +190,7 @@ class AbsensiController extends Controller
         ];
 
         $tanggal = $request->input('tanggal', Carbon::now()->toDateString());
-        $hari = $request->input('hari', $hariMap[date('l', strtotime($tanggal))]);
+        $hari = $hariMap[date('l', strtotime($tanggal))];
 
         if (Auth::user()->role === 'admin') {
             $jadwalQuery = Jadwal::with(['mapel', 'kelas'])->where('hari', $hari);
@@ -208,15 +208,13 @@ class AbsensiController extends Controller
             );
             $kelasOptions = Kelas::all();
             $mapelOptions = MataPelajaran::all();
-            $hariOptions = array_values($hariMap);
 
             return view('absensi.pelajaran', compact(
                 'jadwal',
                 'hari',
                 'tanggal',
                 'kelasOptions',
-                'mapelOptions',
-                'hariOptions'
+                'mapelOptions'
             ));
         }
 

--- a/resources/views/absensi/pelajaran.blade.php
+++ b/resources/views/absensi/pelajaran.blade.php
@@ -17,13 +17,6 @@
         <input type="date" name="tanggal" value="{{ $tanggal }}" class="form-control">
     </div>
     <div class="col-auto">
-        <select name="hari" class="form-control">
-            @foreach($hariOptions as $h)
-                <option value="{{ $h }}" {{ $hari == $h ? 'selected' : '' }}>{{ $h }}</option>
-            @endforeach
-        </select>
-    </div>
-    <div class="col-auto">
         <select name="kelas_id" class="form-control">
             <option value="">-- Semua Kelas --</option>
             @foreach($kelasOptions as $k)

--- a/tests/Feature/AdminPelajaranAbsensiTest.php
+++ b/tests/Feature/AdminPelajaranAbsensiTest.php
@@ -54,7 +54,7 @@ class AdminPelajaranAbsensiTest extends TestCase
         [$admin, , $kelas, $mapel, $jadwal] = $this->createData();
 
         $response = $this->actingAs($admin)
-            ->get('/absensi/pelajaran?hari=Senin&kelas_id='.$kelas->id.'&mapel_id='.$mapel->id);
+            ->get('/absensi/pelajaran?tanggal=2024-07-01&kelas_id='.$kelas->id.'&mapel_id='.$mapel->id);
 
         $response->assertOk();
         $response->assertSee($mapel->nama);

--- a/tests/Feature/FutureAttendanceAccessTest.php
+++ b/tests/Feature/FutureAttendanceAccessTest.php
@@ -50,7 +50,7 @@ class FutureAttendanceAccessTest extends TestCase
             'jam_selesai' => '10:00',
         ]);
 
-        $response = $this->actingAs($admin)->get('/absensi/pelajaran?tanggal=2024-07-02&hari=Selasa');
+        $response = $this->actingAs($admin)->get('/absensi/pelajaran?tanggal=2024-07-02');
 
         $response->assertOk();
         $response->assertSee('<button class="btn btn-sm btn-primary" disabled>Isi Absen</button>', false);


### PR DESCRIPTION
## Summary
- Simplify attendance schedule by deriving day from selected date
- Drop "hari" dropdown from attendance filter form
- Update tests to use date-only filtering

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6896f4774210832b93f18e7cc1690b17