### PR TITLE
Allow admins to print student report cards

### DIFF
--- a/app/Http/Controllers/RaporController.php
+++ b/app/Http/Controllers/RaporController.php
@@ -16,9 +16,13 @@ class RaporController extends Controller
     /**
      * Generate report card PDF using database values.
      */
-    public function cetak(Request $request)
+    public function cetak(Request $request, ?Siswa $siswa = null)
     {
-        $siswa = Siswa::where('user_id', Auth::id())->firstOrFail();
+        if (Auth::user()->role === 'admin') {
+            $siswa = $siswa ?? abort(404);
+        } else {
+            $siswa = Siswa::where('user_id', Auth::id())->firstOrFail();
+        }
 
         $semester = (int) $request->query('semester', 1);
 

--- a/resources/views/siswa/index.blade.php
+++ b/resources/views/siswa/index.blade.php
@@ -54,6 +54,7 @@
             <td>{{ $s->jenis_kelamin }}</td>
             <td>{{ $s->tanggal_lahir }}</td>
             <td>
+                <a href="{{ route('rapor.cetak', $s->id) }}" class="btn btn-sm btn-info">Cetak Rapor</a>
                 <a href="{{ route('siswa.edit', $s->id) }}" class="btn btn-sm btn-warning">Edit</a>
                 <form action="{{ route('siswa.destroy', $s->id) }}" method="POST" class="d-inline" onsubmit="return confirm('Yakin hapus?')">
                     @csrf @method('DELETE')

--- a/routes/web.php
+++ b/routes/web.php
@@ -88,9 +88,11 @@ Route::middleware('auth')->group(function () {
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
 
+// Cetak rapor dapat diakses oleh siswa dan admin
+Route::middleware(['auth', 'role:siswa,admin'])->get('/rapor/cetak/{siswa?}', [RaporController::class, 'cetak'])->name('rapor.cetak');
+
 // Routes khusus siswa untuk melihat data sendiri
 Route::middleware(['auth', 'role:siswa'])->group(function () {
-    Route::get('/rapor/cetak', [RaporController::class, 'cetak'])->name('rapor.cetak');
     Route::get('/saya', [StudentController::class, 'profil'])->name('student.profile');
     Route::get('/saya/absensi', [StudentController::class, 'absensi'])->name('student.absensi');
     Route::get('/saya/nilai', [StudentController::class, 'nilai'])->name('student.nilai');


### PR DESCRIPTION
## Summary
- Let admin access the report card generation route
- Add controller logic so admins can print a selected student's report card
- Provide Cetak Rapor button on student list page

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6896f637a55c832b92d24e3ef285f692