### PR TITLE
Allow homeroom teachers to print report cards

### DIFF
--- a/app/Http/Controllers/RaporController.php
+++ b/app/Http/Controllers/RaporController.php
@@ -18,7 +18,9 @@ class RaporController extends Controller
      */
     public function cetak(Request $request, ?Siswa $siswa = null)
     {
-        if (Auth::user()->role === 'admin') {
+        $role = Auth::user()->role;
+
+        if (in_array($role, ['admin', 'guru'])) {
             $siswa = $siswa ?? abort(404);
         } else {
             $siswa = Siswa::where('user_id', Auth::id())->firstOrFail();
@@ -39,6 +41,12 @@ class RaporController extends Controller
         $kelas = Kelas::with('waliKelas')
             ->where('nama', $siswa->kelas)
             ->first();
+
+        if ($role === 'guru') {
+            $guru = Guru::where('user_id', Auth::id())->firstOrFail();
+            abort_if(!$kelas || $kelas->guru_id !== $guru->id, 403);
+        }
+
         $waliKelas = $kelas->waliKelas ?? null;
 
         $kepalaSekolah = Guru::whereHas('user', function ($query) {

--- a/resources/views/guru/kelas.blade.php
+++ b/resources/views/guru/kelas.blade.php
@@ -32,7 +32,9 @@
             <td>{{ $s->tempat_lahir }}</td>
             <td>{{ $s->jenis_kelamin }}</td>
             <td>{{ $s->tanggal_lahir }}</td>
-            <td></td>
+            <td>
+                <a href="{{ route('rapor.cetak', $s->id) }}" class="btn btn-sm btn-info">Cetak Rapor</a>
+            </td>
         </tr>
         @endforeach
     </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -88,8 +88,8 @@ Route::middleware('auth')->group(function () {
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
 
-// Cetak rapor dapat diakses oleh siswa dan admin
-Route::middleware(['auth', 'role:siswa,admin'])->get('/rapor/cetak/{siswa?}', [RaporController::class, 'cetak'])->name('rapor.cetak');
+// Cetak rapor dapat diakses oleh siswa, wali kelas, dan admin
+Route::middleware(['auth', 'role:siswa,admin,guru'])->get('/rapor/cetak/{siswa?}', [RaporController::class, 'cetak'])->name('rapor.cetak');
 
 // Routes khusus siswa untuk melihat data sendiri
 Route::middleware(['auth', 'role:siswa'])->group(function () {

--- a/tests/Feature/RaporWaliKelasTest.php
+++ b/tests/Feature/RaporWaliKelasTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\{User,Guru,Siswa,Kelas,TahunAjaran,MataPelajaran,Penilaian};
+use Barryvdh\DomPDF\Facade\Pdf;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RaporWaliKelasTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_wali_kelas_can_print_rapor(): void
+    {
+        Pdf::shouldReceive('loadView')->andReturnSelf();
+        Pdf::shouldReceive('setPaper')->andReturnSelf();
+        Pdf::shouldReceive('download')->andReturn(response('PDF', 200, ['Content-Type' => 'application/pdf']));
+
+        $waliUser = User::factory()->create(['role' => 'guru']);
+        $wali = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Wali',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+            'user_id' => $waliUser->id,
+        ]);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $wali->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        $studentUser = User::factory()->create(['role' => 'siswa']);
+        $siswa = Siswa::create([
+            'nama' => 'Siswa',
+            'nisn' => '123',
+            'nama_ortu' => 'Ortu',
+            'kelas' => 'X',
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+            'user_id' => $studentUser->id,
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        Penilaian::create([
+            'siswa_id' => $siswa->id,
+            'mapel_id' => $mapel->id,
+            'semester' => 1,
+            'hadir' => 0,
+            'sakit' => 0,
+            'izin' => 0,
+            'alpha' => 0,
+            'pts' => 0,
+            'pat' => 0,
+        ]);
+
+        $response = $this->actingAs($waliUser)->get('/rapor/cetak/' . $siswa->id);
+
+        $response->assertOk();
+    }
+
+    public function test_non_wali_kelas_cannot_print_rapor(): void
+    {
+        $waliUser = User::factory()->create(['role' => 'guru']);
+        $wali = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Wali',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+            'user_id' => $waliUser->id,
+        ]);
+        $otherUser = User::factory()->create(['role' => 'guru']);
+        Guru::create([
+            'nuptk' => '2',
+            'nama' => 'Guru Lain',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+            'user_id' => $otherUser->id,
+        ]);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $wali->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        $studentUser = User::factory()->create(['role' => 'siswa']);
+        $siswa = Siswa::create([
+            'nama' => 'Siswa',
+            'nisn' => '123',
+            'nama_ortu' => 'Ortu',
+            'kelas' => 'X',
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+            'user_id' => $studentUser->id,
+        ]);
+
+        $response = $this->actingAs($otherUser)->get('/rapor/cetak/' . $siswa->id);
+
+        $response->assertStatus(403);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Permit teachers to print report cards for students in their own class
- Gate report printing so only the assigned homeroom teacher can access a student's report
- Show a "Cetak Rapor" button in the teacher's class roster
- Add feature tests for authorized and unauthorized report access

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6896f9f252fc832b99b1af588f8e5a1c