### PR TITLE
Add jabatan field for Guru

### DIFF
--- a/app/Http/Controllers/GuruController.php
+++ b/app/Http/Controllers/GuruController.php
@@ -16,6 +16,7 @@ class GuruController extends Controller
             $query->where(function ($q) use ($search) {
                 $q->where('nama', 'like', "%{$search}%")
                     ->orWhere('nuptk', 'like', "%{$search}%")
+                    ->orWhere('jabatan', 'like', "%{$search}%")
                     ->orWhere('email', 'like', "%{$search}%");
             });
         }
@@ -35,6 +36,7 @@ public function store(Request $request)
     Guru::create($request->validate([
         'nuptk' => 'required|unique:guru',
         'nama' => 'required',
+        'jabatan' => 'nullable',
         'email' => 'nullable|email|unique:guru',
         'tempat_lahir' => 'required',
         'jenis_kelamin' => 'required',
@@ -54,6 +56,7 @@ public function update(Request $request, Guru $guru)
     $guru->update($request->validate([
         'nuptk' => 'required|unique:guru,nuptk,' . $guru->id,
         'nama' => 'required',
+        'jabatan' => 'nullable',
         'email' => 'nullable|email|unique:guru,email,' . $guru->id,
         'tempat_lahir' => 'required',
         'jenis_kelamin' => 'required',

--- a/app/Models/Guru.php
+++ b/app/Models/Guru.php
@@ -13,6 +13,7 @@ class Guru extends Model
     protected $fillable = [
         'nuptk',
         'nama',
+        'jabatan',
         'email',
         'tempat_lahir',
         'jenis_kelamin',

--- a/database/migrations/2025_07_11_000004_add_jabatan_to_guru_table.php
+++ b/database/migrations/2025_07_11_000004_add_jabatan_to_guru_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('guru', function (Blueprint $table) {
+            $table->string('jabatan')->nullable()->after('nama');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('guru', function (Blueprint $table) {
+            $table->dropColumn('jabatan');
+        });
+    }
+};

--- a/database/seeders/KepalaSekolahSeeder.php
+++ b/database/seeders/KepalaSekolahSeeder.php
@@ -24,6 +24,7 @@ class KepalaSekolahSeeder extends Seeder
             ['nuptk' => '1234567890123456'],
             [
                 'nama' => 'Kepala Sekolah',
+                'jabatan' => 'Kepala Sekolah',
                 'email' => 'kepsek@demo.com',
                 'tempat_lahir' => 'Jakarta',
                 'jenis_kelamin' => 'L',

--- a/resources/views/guru/create.blade.php
+++ b/resources/views/guru/create.blade.php
@@ -26,6 +26,11 @@
         <x-input-error :messages="$errors->get('nama')" class="mt-1" />
     </div>
     <div class="mb-3">
+        <label>Jabatan</label>
+        <input type="text" name="jabatan" class="form-control">
+        <x-input-error :messages="$errors->get('jabatan')" class="mt-1" />
+    </div>
+    <div class="mb-3">
         <label>Email</label>
         <input type="email" name="email" class="form-control">
         <x-input-error :messages="$errors->get('email')" class="mt-1" />

--- a/resources/views/guru/edit.blade.php
+++ b/resources/views/guru/edit.blade.php
@@ -26,6 +26,11 @@
         <x-input-error :messages="$errors->get('nama')" class="mt-1" />
     </div>
     <div class="mb-3">
+        <label>Jabatan</label>
+        <input type="text" name="jabatan" class="form-control" value="{{ $guru->jabatan }}">
+        <x-input-error :messages="$errors->get('jabatan')" class="mt-1" />
+    </div>
+    <div class="mb-3">
         <label>Email</label>
         <input type="email" name="email" class="form-control" value="{{ $guru->email }}">
         <x-input-error :messages="$errors->get('email')" class="mt-1" />

--- a/resources/views/guru/index.blade.php
+++ b/resources/views/guru/index.blade.php
@@ -21,6 +21,7 @@
             <th>ID</th>
             <th>NUPTK</th>
             <th>Nama</th>
+            <th>Jabatan</th>
             <th>Email</th>
             <th>Tempat Lahir</th>
             <th>Jenis Kelamin</th>
@@ -34,6 +35,7 @@
             <td>{{ $g->id }}</td>
             <td>{{ $g->nuptk }}</td>
             <td>{{ $g->nama }}</td>
+            <td>{{ $g->jabatan }}</td>
             <td>{{ $g->email }}</td>
             <td>{{ $g->tempat_lahir }}</td>
             <td>{{ $g->jenis_kelamin }}</td>


### PR DESCRIPTION
## Summary
- add `jabatan` column to `guru` table
- allow CRUD pages and search to manage teacher job titles
- seed kepala sekolah with `jabatan`

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68972592c9fc832bacd9fc8a42a6d613