### PR TITLE
Fetch headmaster by position

### DIFF
--- a/app/Http/Controllers/RaporController.php
+++ b/app/Http/Controllers/RaporController.php
@@ -50,9 +50,7 @@ class RaporController extends Controller
 
         $waliKelas = $kelas?->waliKelas;
 
-        $kepalaSekolah = Guru::whereHas('user', function ($query) {
-            $query->where('role', 'kepala_sekolah');
-        })->first();
+        $kepalaSekolah = Guru::where('jabatan', 'Kepala Sekolah')->first();
 
         $pdf = Pdf::loadView('rapor', [
             'siswa' => $siswa,

--- a/database/seeders/KepalaSekolahSeeder.php
+++ b/database/seeders/KepalaSekolahSeeder.php
@@ -16,7 +16,7 @@ class KepalaSekolahSeeder extends Seeder
             [
                 'name' => 'Kepala Sekolah',
                 'password' => Hash::make('password'),
-                'role' => 'kepala_sekolah',
+                'role' => 'guru',
             ]
         );
 


### PR DESCRIPTION
## Summary
- Look up Kepala Sekolah by `jabatan` instead of user role when generating report cards
- Seed default headmaster account as a `guru` role user

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68972c774518832b8099c7324c3a61c4