### PR TITLE
Implement attendance sessions and student self check-in

### DIFF
--- a/app/Models/Absensi.php
+++ b/app/Models/Absensi.php
@@ -11,7 +11,7 @@ class Absensi extends Model
     use HasFactory;
 
     protected $table = 'absensi';
-    protected $fillable = ['siswa_id', 'mapel_id', 'tanggal', 'status'];
+    protected $fillable = ['siswa_id', 'mapel_id', 'tanggal', 'status', 'check_in_at', 'check_out_at'];
 
     public function siswa()
     {

--- a/app/Models/AbsensiSession.php
+++ b/app/Models/AbsensiSession.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class AbsensiSession extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['jadwal_id', 'tanggal', 'opened_by', 'status_sesi'];
+}

--- a/database/migrations/2025_07_11_000005_add_check_in_out_to_absensi_table.php
+++ b/database/migrations/2025_07_11_000005_add_check_in_out_to_absensi_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('absensi', function (Blueprint $table) {
+            $table->timestamp('check_in_at')->nullable()->after('status');
+            $table->timestamp('check_out_at')->nullable()->after('check_in_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('absensi', function (Blueprint $table) {
+            $table->dropColumn(['check_in_at', 'check_out_at']);
+        });
+    }
+};

--- a/database/migrations/2025_07_11_000006_create_absensi_sessions_table.php
+++ b/database/migrations/2025_07_11_000006_create_absensi_sessions_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('absensi_sessions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('jadwal_id')->constrained('jadwal')->onDelete('cascade');
+            $table->date('tanggal');
+            $table->foreignId('opened_by')->constrained('users');
+            $table->string('status_sesi')->default('open');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('absensi_sessions');
+    }
+};

--- a/resources/views/absensi/session.blade.php
+++ b/resources/views/absensi/session.blade.php
@@ -1,0 +1,21 @@
+@extends('layouts.app')
+
+@section('title', 'Sesi Absensi')
+
+@section('content')
+<h1>Sesi Absensi {{ $jadwal->mapel->nama }} - {{ $jadwal->kelas->nama }}</h1>
+@if(session('success'))
+    <div class="alert alert-success">{{ session('success') }}</div>
+@endif
+@if($session && $session->status_sesi === 'open')
+    <form action="{{ route('absensi.session.end', $jadwal->id) }}" method="POST">
+        @csrf
+        <button class="btn btn-danger">Tutup Sesi</button>
+    </form>
+@else
+    <form action="{{ route('absensi.session.start', $jadwal->id) }}" method="POST">
+        @csrf
+        <button class="btn btn-primary">Mulai Sesi</button>
+    </form>
+@endif
+@endsection

--- a/resources/views/siswa/absen_jadwal.blade.php
+++ b/resources/views/siswa/absen_jadwal.blade.php
@@ -24,6 +24,7 @@
             <tr>
                 <th>Tanggal</th>
                 <th>Status</th>
+                <th>Check-in</th>
             </tr>
         </thead>
         <tbody>
@@ -31,26 +32,19 @@
             <tr>
                 <td>{{ $r->tanggal }}</td>
                 <td>{{ $r->status }}</td>
+                <td>{{ $r->check_in_at }}</td>
             </tr>
             @endforeach
         </tbody>
     </table>
 </div>
 @endif
-<form action="{{ route('student.jadwal.absen', $jadwal->id) }}" method="POST">
+@if($today && $today->check_in_at)
+    <div class="alert alert-info">Check-in pada: {{ $today->check_in_at }}</div>
+@endif
+<form action="{{ route('student.absensi.checkin') }}" method="POST">
     @csrf
-    <div class="mb-3">
-        <label>Status</label>
-        <select name="status" class="form-control" required>
-            <option value="">-- Pilih Status --</option>
-            <option value="Hadir">Hadir</option>
-            <option value="Izin">Izin</option>
-            <option value="Sakit">Sakit</option>
-            <option value="Alpha">Alpha</option>
-        </select>
-        <x-input-error :messages="$errors->get('status')" class="mt-1" />
-    </div>
-    <button class="btn btn-success">Simpan</button>
+    <button class="btn btn-success">Check In</button>
     <a href="{{ route('student.jadwal') }}" class="btn btn-secondary">Kembali</a>
 </form>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -50,6 +50,9 @@ Route::middleware(['auth', 'role:admin,guru'])->group(function () {
     Route::post('/absensi/pelajaran/{jadwal}', [AbsensiController::class, 'pelajaranStore'])->name('absensi.pelajaran.store');
     Route::get('/absensi/rekap', [AbsensiController::class, 'rekap'])->name('absensi.rekap');
     Route::get('/absensi/rekap/export', [AbsensiController::class, 'exportRekap'])->name('absensi.rekap.export');
+    Route::get('/absensi/session/{jadwal}', [AbsensiController::class, 'session'])->name('absensi.session');
+    Route::post('/absensi/session/{jadwal}/start', [AbsensiController::class, 'startSession'])->name('absensi.session.start');
+    Route::post('/absensi/session/{jadwal}/end', [AbsensiController::class, 'endSession'])->name('absensi.session.end');
 });
 
 // Halaman guru untuk melihat siswa di kelasnya
@@ -99,6 +102,7 @@ Route::middleware(['auth', 'role:siswa'])->group(function () {
     Route::get('/saya/jadwal', [StudentController::class, 'jadwal'])->name('student.jadwal');
     Route::get('/saya/jadwal/{jadwal}/absen', [StudentController::class, 'jadwalAbsenForm'])->name('student.jadwal.absen.form');
     Route::post('/saya/jadwal/{jadwal}/absen', [StudentController::class, 'jadwalAbsen'])->name('student.jadwal.absen');
+    Route::post('/saya/absensi/check-in', [StudentController::class, 'sessionCheckIn'])->name('student.absensi.checkin');
 });
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/StudentSelfCheckInTest.php
+++ b/tests/Feature/StudentSelfCheckInTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\Siswa;
+use App\Models\Jadwal;
+use App\Models\TahunAjaran;
+use App\Models\AbsensiSession;
+use App\Models\Absensi;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StudentSelfCheckInTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setupData()
+    {
+        $guruUser = User::factory()->create(['role' => 'guru']);
+        $siswaUser = User::factory()->create(['role' => 'siswa']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+            'user_id' => $guruUser->id,
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        $siswa = Siswa::create([
+            'nama' => 'Siswa 1',
+            'nisn' => '123',
+            'nama_ortu' => 'Orang Tua',
+            'kelas' => $kelas->nama,
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+            'user_id' => $siswaUser->id,
+        ]);
+        $jadwal = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+
+        return [$guruUser, $siswaUser, $siswa, $jadwal, $mapel];
+    }
+
+    public function test_student_can_check_in_during_active_session(): void
+    {
+        Carbon::setTestNow('2024-07-01 07:30:00');
+        [$guruUser, $siswaUser, $siswa, $jadwal, $mapel] = $this->setupData();
+        AbsensiSession::create([
+            'jadwal_id' => $jadwal->id,
+            'tanggal' => '2024-07-01',
+            'opened_by' => $guruUser->id,
+            'status_sesi' => 'open',
+        ]);
+        Absensi::create([
+            'siswa_id' => $siswa->id,
+            'mapel_id' => $mapel->id,
+            'tanggal' => '2024-07-01',
+            'status' => 'Alpha',
+        ]);
+
+        $this->actingAs($siswaUser)
+            ->from('/saya/jadwal/'.$jadwal->id.'/absen')
+            ->post('/saya/absensi/check-in')
+            ->assertRedirect('/saya/jadwal/'.$jadwal->id.'/absen');
+
+        $this->assertDatabaseHas('absensi', [
+            'siswa_id' => $siswa->id,
+            'mapel_id' => $mapel->id,
+            'status' => 'Hadir',
+            'tanggal' => '2024-07-01',
+        ]);
+        $this->assertNotNull(Absensi::first()->check_in_at);
+    }
+
+    public function test_student_cannot_check_in_outside_time(): void
+    {
+        Carbon::setTestNow('2024-07-01 08:30:00');
+        [$guruUser, $siswaUser, $siswa, $jadwal, $mapel] = $this->setupData();
+        AbsensiSession::create([
+            'jadwal_id' => $jadwal->id,
+            'tanggal' => '2024-07-01',
+            'opened_by' => $guruUser->id,
+            'status_sesi' => 'open',
+        ]);
+        Absensi::create([
+            'siswa_id' => $siswa->id,
+            'mapel_id' => $mapel->id,
+            'tanggal' => '2024-07-01',
+            'status' => 'Alpha',
+        ]);
+
+        $this->actingAs($siswaUser)
+            ->post('/saya/absensi/check-in')
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/TeacherSessionAttendanceTest.php
+++ b/tests/Feature/TeacherSessionAttendanceTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\Siswa;
+use App\Models\Jadwal;
+use App\Models\TahunAjaran;
+use App\Models\AbsensiSession;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TeacherSessionAttendanceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_teacher_can_open_and_close_session(): void
+    {
+        Carbon::setTestNow('2024-07-01 07:00:00');
+        $user = User::factory()->create(['role' => 'guru']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+            'user_id' => $user->id,
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        $siswa = Siswa::create([
+            'nama' => 'Siswa 1',
+            'nisn' => '123',
+            'nama_ortu' => 'Orang Tua',
+            'kelas' => $kelas->nama,
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+        ]);
+        $jadwal = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+
+        $this->actingAs($user)
+            ->post('/absensi/session/'.$jadwal->id.'/start')
+            ->assertRedirect('/absensi/session/'.$jadwal->id);
+
+        $this->assertDatabaseHas('absensi_sessions', [
+            'jadwal_id' => $jadwal->id,
+            'status_sesi' => 'open',
+        ]);
+        $this->assertDatabaseHas('absensi', [
+            'siswa_id' => $siswa->id,
+            'status' => 'Alpha',
+        ]);
+
+        $this->actingAs($user)
+            ->post('/absensi/session/'.$jadwal->id.'/end')
+            ->assertRedirect('/absensi/session/'.$jadwal->id);
+
+        $this->assertDatabaseHas('absensi_sessions', [
+            'jadwal_id' => $jadwal->id,
+            'status_sesi' => 'closed',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- track check-in and check-out timestamps on attendance
- allow teachers to open/close attendance sessions per schedule
- enable students to self check-in during active sessions and view check-in time

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68973d233da0832b938360840c50039a