### PR TITLE
Restrict attendance session to schedule

### DIFF
--- a/app/Http/Controllers/AbsensiController.php
+++ b/app/Http/Controllers/AbsensiController.php
@@ -336,7 +336,29 @@ class AbsensiController extends Controller
 
     public function startSession(Jadwal $jadwal)
     {
-        $tanggal = Carbon::now()->toDateString();
+        $now = Carbon::now();
+        $dayMap = [
+            'Monday' => 'Senin',
+            'Tuesday' => 'Selasa',
+            'Wednesday' => 'Rabu',
+            'Thursday' => 'Kamis',
+            'Friday' => 'Jumat',
+            'Saturday' => 'Sabtu',
+            'Sunday' => 'Minggu',
+        ];
+
+        $currentDay = $dayMap[$now->format('l')] ?? '';
+        $currentTime = $now->format('H:i');
+
+        if (
+            $currentDay !== $jadwal->hari ||
+            $currentTime < $jadwal->jam_mulai ||
+            $currentTime > $jadwal->jam_selesai
+        ) {
+            abort(403, 'Sesi absensi hanya bisa dibuka sesuai jadwal');
+        }
+
+        $tanggal = $now->toDateString();
         AbsensiSession::create([
             'jadwal_id' => $jadwal->id,
             'tanggal' => $tanggal,

--- a/resources/views/absensi/session.blade.php
+++ b/resources/views/absensi/session.blade.php
@@ -7,6 +7,22 @@
 @if(session('success'))
     <div class="alert alert-success">{{ session('success') }}</div>
 @endif
+@php
+    $dayMap = [
+        'Monday' => 'Senin',
+        'Tuesday' => 'Selasa',
+        'Wednesday' => 'Rabu',
+        'Thursday' => 'Kamis',
+        'Friday' => 'Jumat',
+        'Saturday' => 'Sabtu',
+        'Sunday' => 'Minggu',
+    ];
+    $now = \Carbon\Carbon::now();
+    $currentDay = $dayMap[$now->format('l')] ?? '';
+    $currentTime = $now->format('H:i');
+    $canStart = $currentDay === $jadwal->hari && $currentTime >= $jadwal->jam_mulai && $currentTime <= $jadwal->jam_selesai;
+@endphp
+
 @if($session && $session->status_sesi === 'open')
     <form action="{{ route('absensi.session.end', $jadwal->id) }}" method="POST">
         @csrf
@@ -15,7 +31,7 @@
 @else
     <form action="{{ route('absensi.session.start', $jadwal->id) }}" method="POST">
         @csrf
-        <button class="btn btn-primary">Mulai Sesi</button>
+        <button class="btn btn-primary" {{ $canStart ? '' : 'disabled' }}>Mulai Sesi</button>
     </form>
 @endif
 @endsection

--- a/tests/Feature/TeacherSessionAttendanceTest.php
+++ b/tests/Feature/TeacherSessionAttendanceTest.php
@@ -82,4 +82,108 @@ class TeacherSessionAttendanceTest extends TestCase
             'status_sesi' => 'closed',
         ]);
     }
+
+    public function test_teacher_cannot_open_session_before_schedule(): void
+    {
+        Carbon::setTestNow('2024-07-01 06:00:00');
+        $user = User::factory()->create(['role' => 'guru']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+            'user_id' => $user->id,
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        Siswa::create([
+            'nama' => 'Siswa 1',
+            'nisn' => '123',
+            'nama_ortu' => 'Orang Tua',
+            'kelas' => $kelas->nama,
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+        ]);
+        $jadwal = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+
+        $this->actingAs($user)
+            ->post('/absensi/session/'.$jadwal->id.'/start')
+            ->assertStatus(403);
+
+        $this->assertDatabaseMissing('absensi_sessions', [
+            'jadwal_id' => $jadwal->id,
+            'tanggal' => '2024-07-01',
+        ]);
+    }
+
+    public function test_teacher_cannot_open_session_after_schedule(): void
+    {
+        Carbon::setTestNow('2024-07-01 09:00:00');
+        $user = User::factory()->create(['role' => 'guru']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+            'user_id' => $user->id,
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        Siswa::create([
+            'nama' => 'Siswa 1',
+            'nisn' => '123',
+            'nama_ortu' => 'Orang Tua',
+            'kelas' => $kelas->nama,
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+        ]);
+        $jadwal = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+
+        $this->actingAs($user)
+            ->post('/absensi/session/'.$jadwal->id.'/start')
+            ->assertStatus(403);
+
+        $this->assertDatabaseMissing('absensi_sessions', [
+            'jadwal_id' => $jadwal->id,
+            'tanggal' => '2024-07-01',
+        ]);
+    }
 }


### PR DESCRIPTION
## Summary
- Prevent teachers from opening attendance sessions outside their scheduled day and time
- Disable session start button when current time is outside the schedule
- Add tests ensuring sessions cannot start before or after scheduled time

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68974854bbb8832b9c0fdb8bbf6ae7bd