### PR TITLE
Merge consecutive schedule slots into unified block

### DIFF
--- a/app/Http/Controllers/AbsensiController.php
+++ b/app/Http/Controllers/AbsensiController.php
@@ -250,27 +250,6 @@ class AbsensiController extends Controller
         ]);
     }
 
-    private function mergeConsecutiveJadwal($jadwal)
-    {
-        $merged = collect();
-        foreach ($jadwal as $item) {
-            if ($merged->isNotEmpty()) {
-                $last = $merged->last();
-                if ($last->kelas_id === $item->kelas_id &&
-                    $last->mapel_id === $item->mapel_id &&
-                    $last->guru_id === $item->guru_id &&
-                    $last->jam_selesai === $item->jam_mulai) {
-                    $last->jam_selesai = $item->jam_selesai;
-
-                    continue;
-                }
-            }
-            $merged->push(clone $item);
-        }
-
-        return $merged;
-    }
-
     public function pelajaranForm(Request $request, Jadwal $jadwal)
     {
         $guru = Guru::where('user_id', Auth::id())->first();

--- a/app/Models/Jadwal.php
+++ b/app/Models/Jadwal.php
@@ -27,6 +27,13 @@ class Jadwal extends Model
         return $this->belongsTo(Guru::class);
     }
 
+    /**
+     * Merge consecutive schedule entries belonging to the same class, subject,
+     * and teacher. Entries must be ordered by start time.
+     *
+     * @param \Illuminate\Support\Collection|\Illuminate\Database\Eloquent\Collection $jadwal
+     * @return \Illuminate\Support\Collection
+     */
     public static function mergeConsecutive($jadwal)
     {
         $merged = collect();


### PR DESCRIPTION
## Summary
- centralize schedule merging with `Jadwal::mergeConsecutive`
- use centralized merge logic in Absensi controller and remove old helper

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68975af8b350832b806411b7afcef291