### PR TITLE
Fix time parsing for attendance sessions

### DIFF
--- a/app/Http/Controllers/AbsensiController.php
+++ b/app/Http/Controllers/AbsensiController.php
@@ -327,8 +327,8 @@ class AbsensiController extends Controller
         ];
 
         $currentDay = $dayMap[$now->format('l')] ?? '';
-        $startTime = Carbon::createFromFormat('H:i', $jadwal->jam_mulai);
-        $endTime = Carbon::createFromFormat('H:i', $jadwal->jam_selesai);
+        $startTime = Carbon::parse($jadwal->jam_mulai);
+        $endTime = Carbon::parse($jadwal->jam_selesai);
 
         if (
             $currentDay !== $jadwal->hari ||

--- a/resources/views/absensi/session.blade.php
+++ b/resources/views/absensi/session.blade.php
@@ -19,8 +19,8 @@
     ];
     $now = \Carbon\Carbon::now();
     $currentDay = $dayMap[$now->format('l')] ?? '';
-    $start = \Carbon\Carbon::createFromFormat('H:i', $jadwal->jam_mulai);
-    $end = \Carbon\Carbon::createFromFormat('H:i', $jadwal->jam_selesai);
+    $start = \Carbon\Carbon::parse($jadwal->jam_mulai);
+    $end = \Carbon\Carbon::parse($jadwal->jam_selesai);
     $canStart = $currentDay === $jadwal->hari && $now->between($start, $end);
 @endphp
 


### PR DESCRIPTION
## Summary
- Use `Carbon::parse` for schedule start and end times to handle HH:mm:ss values
- Update session blade to parse schedule times accordingly

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68975dae4c88832b81bc7673a9fe66d4