### PR TITLE
Handle session time parsing without Carbon::parse

### DIFF
--- a/app/Http/Controllers/AbsensiController.php
+++ b/app/Http/Controllers/AbsensiController.php
@@ -327,8 +327,8 @@ class AbsensiController extends Controller
         ];
 
         $currentDay = $dayMap[$now->format('l')] ?? '';
-        $startTime = Carbon::parse($jadwal->jam_mulai);
-        $endTime = Carbon::parse($jadwal->jam_selesai);
+        $startTime = $now->copy()->setTimeFromTimeString($jadwal->jam_mulai);
+        $endTime = $now->copy()->setTimeFromTimeString($jadwal->jam_selesai);
 
         if (
             $currentDay !== $jadwal->hari ||


### PR DESCRIPTION
## Summary
- avoid Carbon::parse when comparing schedule times in AbsensiController

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_6897619f53f0832b8e91576f85c41157