### PR TITLE
Fix self check-in for long class sessions

### DIFF
--- a/app/Models/AbsensiSession.php
+++ b/app/Models/AbsensiSession.php
@@ -10,4 +10,9 @@ class AbsensiSession extends Model
     use HasFactory;
 
     protected $fillable = ['jadwal_id', 'tanggal', 'opened_by', 'status_sesi'];
+
+    public function jadwal()
+    {
+        return $this->belongsTo(Jadwal::class);
+    }
 }


### PR DESCRIPTION
## Summary
- allow students to self check-in during multi-hour sessions
- cover extended and consecutive schedule check-in flows

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6897643a1430832b82c412abf00aa0b0