### PR TITLE
Fix attendance session button not updating after reopening

### DIFF
--- a/app/Http/Controllers/AbsensiController.php
+++ b/app/Http/Controllers/AbsensiController.php
@@ -308,6 +308,7 @@ class AbsensiController extends Controller
     {
         $session = AbsensiSession::where('jadwal_id', $jadwal->id)
             ->where('tanggal', Carbon::now()->toDateString())
+            ->orderByDesc('id')
             ->first();
 
         $now = Carbon::now();

--- a/tests/Feature/StartSessionTest.php
+++ b/tests/Feature/StartSessionTest.php
@@ -87,4 +87,18 @@ class StartSessionTest extends TestCase
             'status_sesi' => 'open',
         ]);
     }
+
+    public function test_teacher_can_restart_session_after_closing(): void
+    {
+        Carbon::setTestNow('2024-07-01 08:30:00');
+        [$guruUser, $jadwal] = $this->setupData();
+
+        $this->actingAs($guruUser)->post(route('absensi.session.start', $jadwal->id));
+        $this->actingAs($guruUser)->post(route('absensi.session.end', $jadwal->id));
+        $this->actingAs($guruUser)->post(route('absensi.session.start', $jadwal->id));
+
+        $response = $this->actingAs($guruUser)->get(route('absensi.session', $jadwal->id));
+
+        $response->assertSee('Tutup Sesi');
+    }
 }


### PR DESCRIPTION
## Summary
- ensure latest attendance session is loaded so button toggles correctly
- test restarting attendance sessions after closing

## Testing
- `composer install`
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_689777da41dc832bae699e7c62a003c4