### PR TITLE
Honor multi-hour schedules when opening sessions

### DIFF
--- a/app/Http/Controllers/AbsensiController.php
+++ b/app/Http/Controllers/AbsensiController.php
@@ -313,7 +313,7 @@ class AbsensiController extends Controller
 
         $now = Carbon::now();
         $start = $now->copy()->setTimeFromTimeString($jadwal->jam_mulai);
-        $end = $now->copy()->setTimeFromTimeString($this->extendedEndTime($jadwal));
+        $end = $now->copy()->setTimeFromTimeString($jadwal->extendedEndTime());
         $canStart =
             $now->between($start, $end)
             && $now->locale('id')->isoFormat('dddd') === $jadwal->hari
@@ -327,7 +327,7 @@ class AbsensiController extends Controller
         $now = Carbon::now();
         $currentDay = $now->locale('id')->isoFormat('dddd');
         $startTime = $now->copy()->setTimeFromTimeString($jadwal->jam_mulai);
-        $endTime = $now->copy()->setTimeFromTimeString($this->extendedEndTime($jadwal));
+        $endTime = $now->copy()->setTimeFromTimeString($jadwal->extendedEndTime());
 
         if (
             $currentDay !== $jadwal->hari ||
@@ -355,27 +355,6 @@ class AbsensiController extends Controller
         }
 
         return redirect()->route('absensi.session', $jadwal->id)->with('success', 'Sesi absensi dibuka');
-    }
-
-    private function extendedEndTime(Jadwal $jadwal): string
-    {
-        $end = $jadwal->jam_selesai;
-        $current = $jadwal;
-        while (true) {
-            $next = Jadwal::where('kelas_id', $current->kelas_id)
-                ->where('mapel_id', $current->mapel_id)
-                ->where('guru_id', $current->guru_id)
-                ->where('hari', $current->hari)
-                ->where('jam_mulai', $end)
-                ->first();
-            if (! $next) {
-                break;
-            }
-            $end = $next->jam_selesai;
-            $current = $next;
-        }
-
-        return $end;
     }
 
     private function hasPrecedingSlot(Jadwal $jadwal): bool

--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -96,7 +96,9 @@ class StudentController extends Controller
         $hari = $now->locale('id')->isoFormat('dddd');
         $time = $now->format('H:i');
 
-        if ($hari !== $jadwal->hari || $time < $jadwal->jam_mulai || $time > $jadwal->jam_selesai) {
+        $endTime = $jadwal->extendedEndTime();
+
+        if ($hari !== $jadwal->hari || $time < $jadwal->jam_mulai || $time > $endTime) {
             abort(403);
         }
 
@@ -127,7 +129,9 @@ class StudentController extends Controller
         $hari = $now->locale('id')->isoFormat('dddd');
         $time = $now->format('H:i');
 
-        if ($hari !== $jadwal->hari || $time < $jadwal->jam_mulai || $time > $jadwal->jam_selesai) {
+        $endTime = $jadwal->extendedEndTime();
+
+        if ($hari !== $jadwal->hari || $time < $jadwal->jam_mulai || $time > $endTime) {
             abort(403);
         }
 
@@ -168,21 +172,7 @@ class StudentController extends Controller
         }
 
         $baseJadwal = $session->jadwal;
-        $endTime = $baseJadwal->jam_selesai;
-        $current = $baseJadwal;
-        while (true) {
-            $next = Jadwal::where('kelas_id', $current->kelas_id)
-                ->where('mapel_id', $current->mapel_id)
-                ->where('guru_id', $current->guru_id)
-                ->where('hari', $current->hari)
-                ->where('jam_mulai', $endTime)
-                ->first();
-            if (! $next) {
-                break;
-            }
-            $endTime = $next->jam_selesai;
-            $current = $next;
-        }
+        $endTime = $baseJadwal->extendedEndTime();
 
         if ($time > $endTime) {
             abort(403);

--- a/app/Models/Jadwal.php
+++ b/app/Models/Jadwal.php
@@ -55,4 +55,32 @@ class Jadwal extends Model
 
         return $merged;
     }
+
+    /**
+     * Determine the end time of a block of consecutive schedules that belong to
+     * the same class, subject and teacher.
+     */
+    public function extendedEndTime(): string
+    {
+        $end = $this->jam_selesai;
+        $current = $this;
+
+        while (true) {
+            $next = self::where('kelas_id', $current->kelas_id)
+                ->where('mapel_id', $current->mapel_id)
+                ->where('guru_id', $current->guru_id)
+                ->where('hari', $current->hari)
+                ->where('jam_mulai', $end)
+                ->first();
+
+            if (! $next) {
+                break;
+            }
+
+            $end = $next->jam_selesai;
+            $current = $next;
+        }
+
+        return $end;
+    }
 }

--- a/tests/Feature/StudentExtendedSessionFormTest.php
+++ b/tests/Feature/StudentExtendedSessionFormTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\Guru;
+use App\Models\MataPelajaran;
+use App\Models\Kelas;
+use App\Models\Siswa;
+use App\Models\Jadwal;
+use App\Models\AbsensiSession;
+use App\Models\TahunAjaran;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StudentExtendedSessionFormTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_student_can_access_form_until_extended_end(): void
+    {
+        Carbon::setTestNow('2024-07-01 08:30:00');
+
+        $studentUser = User::factory()->create(['role' => 'siswa']);
+        $teacherUser = User::factory()->create(['role' => 'guru']);
+        $guru = Guru::create([
+            'nuptk' => '1',
+            'nama' => 'Guru',
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '1980-01-01',
+            'user_id' => $teacherUser->id,
+        ]);
+        $mapel = MataPelajaran::create(['nama' => 'IPA']);
+        $ta = TahunAjaran::create([
+            'nama' => '2024/2025',
+            'start_date' => '2024-07-01',
+            'end_date' => '2025-06-30',
+        ]);
+        $kelas = Kelas::create([
+            'nama' => 'X',
+            'guru_id' => $guru->id,
+            'tahun_ajaran_id' => $ta->id,
+        ]);
+        Siswa::create([
+            'nama' => 'Siswa 1',
+            'nisn' => '123',
+            'nama_ortu' => 'Orang Tua',
+            'kelas' => $kelas->nama,
+            'tahun_ajaran_id' => $ta->id,
+            'tempat_lahir' => 'Kota',
+            'jenis_kelamin' => 'L',
+            'tanggal_lahir' => '2000-01-01',
+            'user_id' => $studentUser->id,
+        ]);
+
+        $first = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '07:00',
+            'jam_selesai' => '08:00',
+        ]);
+        $second = Jadwal::create([
+            'kelas_id' => $kelas->id,
+            'mapel_id' => $mapel->id,
+            'guru_id' => $guru->id,
+            'hari' => 'Senin',
+            'jam_mulai' => '08:00',
+            'jam_selesai' => '09:00',
+        ]);
+
+        AbsensiSession::create([
+            'jadwal_id' => $first->id,
+            'tanggal' => '2024-07-01',
+            'opened_by' => $teacherUser->id,
+            'status_sesi' => 'open',
+        ]);
+
+        $response = $this->actingAs($studentUser)
+            ->get(route('student.jadwal.absen.form', $first->id));
+
+        $response->assertOk();
+    }
+}


### PR DESCRIPTION
## Summary
- Derive end time for consecutive schedule blocks via new `Jadwal::extendedEndTime`
- Use extended end time in attendance controllers so sessions stay open for the entire block
- Add test ensuring multi-hour sessions remain accessible to students

## Testing
- `./vendor/bin/phpunit --testsuite Feature --stop-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_689781129f74832bb006006636214aa0