### PR TITLE
Add optional password to absensi sessions

### DIFF
--- a/app/Models/AbsensiSession.php
+++ b/app/Models/AbsensiSession.php
@@ -9,7 +9,7 @@ class AbsensiSession extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['jadwal_id', 'tanggal', 'opened_by', 'status_sesi'];
+    protected $fillable = ['jadwal_id', 'tanggal', 'opened_by', 'status_sesi', 'password'];
 
     public function jadwal()
     {

--- a/database/migrations/2025_07_11_000007_add_password_to_absensi_sessions_table.php
+++ b/database/migrations/2025_07_11_000007_add_password_to_absensi_sessions_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('absensi_sessions', function (Blueprint $table) {
+            $table->string('password')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('absensi_sessions', function (Blueprint $table) {
+            $table->dropColumn('password');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add migration to allow optional password on absensi sessions
- allow mass assignment of password on AbsensiSession model

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68979848a890832ba5f9a738b289a183