### PR TITLE
Add password requirement when starting attendance sessions

### DIFF
--- a/app/Http/Controllers/AbsensiController.php
+++ b/app/Http/Controllers/AbsensiController.php
@@ -327,7 +327,7 @@ class AbsensiController extends Controller
         ]);
     }
 
-    public function startSession(Jadwal $jadwal)
+    public function startSession(Request $request, Jadwal $jadwal)
     {
         $base = $jadwal->baseSlot();
         $now = Carbon::now();
@@ -340,12 +340,17 @@ class AbsensiController extends Controller
             abort(403, 'Sesi absensi hanya bisa dibuka sesuai jadwal');
         }
 
+        $validated = $request->validate([
+            'password' => 'required|min:4',
+        ]);
+
         $tanggal = $now->toDateString();
         AbsensiSession::create([
             'jadwal_id' => $base->id,
             'tanggal' => $tanggal,
             'opened_by' => Auth::id(),
             'status_sesi' => 'open',
+            'password' => bcrypt($validated['password']),
         ]);
 
         $siswaIds = Siswa::where('kelas', $base->kelas->nama)->pluck('id');

--- a/resources/views/absensi/session.blade.php
+++ b/resources/views/absensi/session.blade.php
@@ -15,6 +15,13 @@
 @else
     <form action="{{ route('absensi.session.start', $jadwal->id) }}" method="POST">
         @csrf
+        @if(! $session)
+            <div class="mb-3">
+                <label>Password</label>
+                <input type="password" name="password" class="form-control" required>
+                <x-input-error :messages="$errors->get('password')" class="mt-1" />
+            </div>
+        @endif
         <button class="btn btn-primary" {{ $canStart ? '' : 'disabled' }}>Mulai Sesi</button>
     </form>
 @endif

--- a/tests/Feature/StartSessionTest.php
+++ b/tests/Feature/StartSessionTest.php
@@ -70,7 +70,7 @@ class StartSessionTest extends TestCase
         [$guruUser, $jadwal] = $this->setupData();
 
         $this->actingAs($guruUser)
-            ->post(route('absensi.session.start', $jadwal->id))
+            ->post(route('absensi.session.start', $jadwal->id), ['password' => 'secret123'])
             ->assertRedirect(route('absensi.session', $jadwal->id));
 
         $this->assertDatabaseHas('absensi_sessions', [
@@ -85,9 +85,9 @@ class StartSessionTest extends TestCase
         Carbon::setTestNow('2024-07-01 07:30:00');
         [$guruUser, $jadwal] = $this->setupData();
 
-        $this->actingAs($guruUser)->post(route('absensi.session.start', $jadwal->id));
+        $this->actingAs($guruUser)->post(route('absensi.session.start', $jadwal->id), ['password' => 'secret123']);
         $this->actingAs($guruUser)->post(route('absensi.session.end', $jadwal->id));
-        $this->actingAs($guruUser)->post(route('absensi.session.start', $jadwal->id));
+        $this->actingAs($guruUser)->post(route('absensi.session.start', $jadwal->id), ['password' => 'secret123']);
 
         $response = $this->actingAs($guruUser)->get(route('absensi.session', $jadwal->id));
 
@@ -109,7 +109,7 @@ class StartSessionTest extends TestCase
         Carbon::setTestNow('2024-07-01 08:30:00');
 
         $this->actingAs($guruUser)
-            ->post(route('absensi.session.start', $secondSchedule->id))
+            ->post(route('absensi.session.start', $secondSchedule->id), ['password' => 'secret123'])
             ->assertRedirect(route('absensi.session', $firstSchedule->id));
 
         $this->assertDatabaseHas('absensi_sessions', [

--- a/tests/Feature/TeacherExtendedSessionStartTest.php
+++ b/tests/Feature/TeacherExtendedSessionStartTest.php
@@ -70,7 +70,7 @@ class TeacherExtendedSessionStartTest extends TestCase
         ]);
 
         $this->actingAs($teacherUser)
-            ->post(route('absensi.session.start', $second->id))
+            ->post(route('absensi.session.start', $second->id), ['password' => 'secret123'])
             ->assertRedirect(route('absensi.session', $first->id));
 
         $this->assertDatabaseHas('absensi_sessions', [

--- a/tests/Feature/TeacherSessionAttendanceTest.php
+++ b/tests/Feature/TeacherSessionAttendanceTest.php
@@ -61,7 +61,7 @@ class TeacherSessionAttendanceTest extends TestCase
         ]);
 
         $this->actingAs($user)
-            ->post('/absensi/session/'.$jadwal->id.'/start')
+            ->post('/absensi/session/'.$jadwal->id.'/start', ['password' => 'secret123'])
             ->assertRedirect('/absensi/session/'.$jadwal->id);
 
         $this->assertDatabaseHas('absensi_sessions', [
@@ -126,7 +126,7 @@ class TeacherSessionAttendanceTest extends TestCase
         ]);
 
         $this->actingAs($user)
-            ->post('/absensi/session/'.$jadwal->id.'/start')
+            ->post('/absensi/session/'.$jadwal->id.'/start', ['password' => 'secret123'])
             ->assertStatus(403);
 
         $this->assertDatabaseMissing('absensi_sessions', [
@@ -178,7 +178,7 @@ class TeacherSessionAttendanceTest extends TestCase
         ]);
 
         $this->actingAs($user)
-            ->post('/absensi/session/'.$jadwal->id.'/start')
+            ->post('/absensi/session/'.$jadwal->id.'/start', ['password' => 'secret123'])
             ->assertStatus(403);
 
         $this->assertDatabaseMissing('absensi_sessions', [
@@ -230,7 +230,7 @@ class TeacherSessionAttendanceTest extends TestCase
         ]);
 
         $this->actingAs($user)
-            ->post('/absensi/session/'.$jadwal->id.'/start')
+            ->post('/absensi/session/'.$jadwal->id.'/start', ['password' => 'secret123'])
             ->assertRedirect('/absensi/session/'.$jadwal->id);
 
         $this->assertDatabaseHas('absensi_sessions', [


### PR DESCRIPTION
## Summary
- require password when teachers start a new attendance session and store it hashed
- prompt for session password when no previous session exists

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68979b6aafc0832ba64fa7868ebd7aba