### PR TITLE
Require session password for student check-in

### DIFF
--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -9,6 +9,7 @@ use App\Models\Kelas;
 use App\Models\Penilaian;
 use App\Models\AbsensiSession;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Http\Request;
 use Carbon\Carbon;
 
@@ -147,8 +148,12 @@ class StudentController extends Controller
         return redirect()->route('student.jadwal')->with('success', 'Absensi berhasil dicatat');
     }
 
-    public function sessionCheckIn()
+    public function sessionCheckIn(Request $request)
     {
+        $request->validate([
+            'password' => 'required',
+        ]);
+
         $siswa = Siswa::where('user_id', Auth::id())->firstOrFail();
         $kelas = Kelas::where('nama', $siswa->kelas)->first();
         if (! $kelas) {
@@ -168,6 +173,10 @@ class StudentController extends Controller
             })
             ->first();
         if (! $session) {
+            abort(403);
+        }
+
+        if (! Hash::check($request->password, $session->password)) {
             abort(403);
         }
 

--- a/resources/views/siswa/absen_jadwal.blade.php
+++ b/resources/views/siswa/absen_jadwal.blade.php
@@ -44,6 +44,9 @@
 @else
 <form action="{{ route('student.absensi.checkin') }}" method="POST">
     @csrf
+    <div class="mb-3">
+        <input type="password" name="password" class="form-control" placeholder="Password" required>
+    </div>
     <button class="btn btn-success">Check In</button>
     <a href="{{ route('student.jadwal') }}" class="btn btn-secondary">Kembali</a>
 </form>


### PR DESCRIPTION
## Summary
- add password field to student check-in form
- validate and verify session password before recording attendance

## Testing
- `php artisan test` *(fails: The password field is required; Tests: 5 failed, 81 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68979d8f3ee8832b83a447e8d670936b