### PR TITLE
Require password on student session check-in tests

### DIFF
--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -11,6 +11,7 @@ use App\Models\AbsensiSession;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Hash;
 
 class StudentController extends Controller
 {
@@ -147,13 +148,17 @@ class StudentController extends Controller
         return redirect()->route('student.jadwal')->with('success', 'Absensi berhasil dicatat');
     }
 
-    public function sessionCheckIn()
+    public function sessionCheckIn(Request $request)
     {
         $siswa = Siswa::where('user_id', Auth::id())->firstOrFail();
         $kelas = Kelas::where('nama', $siswa->kelas)->first();
         if (! $kelas) {
             abort(403);
         }
+
+        $validated = $request->validate([
+            'password' => 'required',
+        ]);
 
         $now = Carbon::now();
         $hari = $now->locale('id')->isoFormat('dddd');
@@ -167,7 +172,7 @@ class StudentController extends Controller
                     ->where('jam_mulai', '<=', $time);
             })
             ->first();
-        if (! $session) {
+        if (! $session || ! Hash::check($validated['password'], $session->password)) {
             abort(403);
         }
 

--- a/tests/Feature/StudentSelfCheckInTest.php
+++ b/tests/Feature/StudentSelfCheckInTest.php
@@ -65,7 +65,7 @@ class StudentSelfCheckInTest extends TestCase
         return [$guruUser, $siswaUser, $siswa, $jadwal, $mapel];
     }
 
-    public function test_student_can_check_in_during_active_session(): void
+    public function test_student_can_check_in_with_correct_password(): void
     {
         Carbon::setTestNow('2024-07-01 07:30:00');
         [$guruUser, $siswaUser, $siswa, $jadwal, $mapel] = $this->setupData();
@@ -74,6 +74,7 @@ class StudentSelfCheckInTest extends TestCase
             'tanggal' => '2024-07-01',
             'opened_by' => $guruUser->id,
             'status_sesi' => 'open',
+            'password' => bcrypt('secret123'),
         ]);
         Absensi::create([
             'siswa_id' => $siswa->id,
@@ -84,7 +85,7 @@ class StudentSelfCheckInTest extends TestCase
 
         $this->actingAs($siswaUser)
             ->from('/saya/jadwal/'.$jadwal->id.'/absen')
-            ->post('/saya/absensi/check-in')
+            ->post('/saya/absensi/check-in', ['password' => 'secret123'])
             ->assertRedirect('/saya/jadwal/'.$jadwal->id.'/absen');
 
         $this->assertDatabaseHas('absensi', [
@@ -94,6 +95,29 @@ class StudentSelfCheckInTest extends TestCase
             'tanggal' => '2024-07-01',
         ]);
         $this->assertNotNull(Absensi::first()->check_in_at);
+    }
+
+    public function test_student_cannot_check_in_with_wrong_password(): void
+    {
+        Carbon::setTestNow('2024-07-01 07:30:00');
+        [$guruUser, $siswaUser, $siswa, $jadwal, $mapel] = $this->setupData();
+        AbsensiSession::create([
+            'jadwal_id' => $jadwal->id,
+            'tanggal' => '2024-07-01',
+            'opened_by' => $guruUser->id,
+            'status_sesi' => 'open',
+            'password' => bcrypt('secret123'),
+        ]);
+        Absensi::create([
+            'siswa_id' => $siswa->id,
+            'mapel_id' => $mapel->id,
+            'tanggal' => '2024-07-01',
+            'status' => 'Alpha',
+        ]);
+
+        $this->actingAs($siswaUser)
+            ->post('/saya/absensi/check-in', ['password' => 'wrong'])
+            ->assertForbidden();
     }
 
     public function test_student_can_check_in_during_extended_schedule(): void
@@ -106,6 +130,7 @@ class StudentSelfCheckInTest extends TestCase
             'tanggal' => '2024-07-01',
             'opened_by' => $guruUser->id,
             'status_sesi' => 'open',
+            'password' => bcrypt('secret123'),
         ]);
         Absensi::create([
             'siswa_id' => $siswa->id,
@@ -116,7 +141,7 @@ class StudentSelfCheckInTest extends TestCase
 
         $this->actingAs($siswaUser)
             ->from('/saya/jadwal/'.$jadwal->id.'/absen')
-            ->post('/saya/absensi/check-in')
+            ->post('/saya/absensi/check-in', ['password' => 'secret123'])
             ->assertRedirect('/saya/jadwal/'.$jadwal->id.'/absen');
 
         $this->assertDatabaseHas('absensi', [
@@ -146,6 +171,7 @@ class StudentSelfCheckInTest extends TestCase
             'tanggal' => '2024-07-01',
             'opened_by' => $guruUser->id,
             'status_sesi' => 'open',
+            'password' => bcrypt('secret123'),
         ]);
         Absensi::create([
             'siswa_id' => $siswa->id,
@@ -156,7 +182,7 @@ class StudentSelfCheckInTest extends TestCase
 
         $this->actingAs($siswaUser)
             ->from('/saya/jadwal/'.$jadwal1->id.'/absen')
-            ->post('/saya/absensi/check-in')
+            ->post('/saya/absensi/check-in', ['password' => 'secret123'])
             ->assertRedirect('/saya/jadwal/'.$jadwal1->id.'/absen');
 
         $this->assertDatabaseHas('absensi', [
@@ -177,6 +203,7 @@ class StudentSelfCheckInTest extends TestCase
             'tanggal' => '2024-07-01',
             'opened_by' => $guruUser->id,
             'status_sesi' => 'open',
+            'password' => bcrypt('secret123'),
         ]);
         Absensi::create([
             'siswa_id' => $siswa->id,
@@ -186,7 +213,7 @@ class StudentSelfCheckInTest extends TestCase
         ]);
 
         $this->actingAs($siswaUser)
-            ->post('/saya/absensi/check-in')
+            ->post('/saya/absensi/check-in', ['password' => 'secret123'])
             ->assertForbidden();
     }
 
@@ -199,6 +226,7 @@ class StudentSelfCheckInTest extends TestCase
             'tanggal' => '2024-07-01',
             'opened_by' => $guruUser->id,
             'status_sesi' => 'open',
+            'password' => bcrypt('secret123'),
         ]);
         Absensi::create([
             'siswa_id' => $siswa->id,
@@ -209,12 +237,12 @@ class StudentSelfCheckInTest extends TestCase
 
         $this->actingAs($siswaUser)
             ->from('/saya/jadwal/'.$jadwal->id.'/absen')
-            ->post('/saya/absensi/check-in')
+            ->post('/saya/absensi/check-in', ['password' => 'secret123'])
             ->assertRedirect('/saya/jadwal/'.$jadwal->id.'/absen');
 
         $this->actingAs($siswaUser)
             ->from('/saya/jadwal/'.$jadwal->id.'/absen')
-            ->post('/saya/absensi/check-in')
+            ->post('/saya/absensi/check-in', ['password' => 'secret123'])
             ->assertRedirect('/saya/jadwal/'.$jadwal->id.'/absen')
             ->assertSessionHasErrors('check_in');
 


### PR DESCRIPTION
## Summary
- enforce password validation for student self check-in
- cover student self check-in success and failure scenarios with passwords

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68979efe575c832ba8eaca3c5bcb7101