### PR TITLE
Generate random password for attendance sessions

### DIFF
--- a/app/Http/Controllers/AbsensiController.php
+++ b/app/Http/Controllers/AbsensiController.php
@@ -14,6 +14,7 @@ use App\Models\Siswa;
 use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Maatwebsite\Excel\Facades\Excel;
 
@@ -350,17 +351,14 @@ class AbsensiController extends Controller
             abort(403, 'Sesi absensi hanya bisa dibuka sesuai jadwal');
         }
 
-        $validated = $request->validate([
-            'password' => 'required|min:4',
-        ]);
-
+        $password = Str::random(6);
         $tanggal = $now->toDateString();
         AbsensiSession::create([
             'jadwal_id' => $base->id,
             'tanggal' => $tanggal,
             'opened_by' => Auth::id(),
             'status_sesi' => 'open',
-            'password' => bcrypt($validated['password']),
+            'password' => bcrypt($password),
         ]);
 
         $siswaIds = Siswa::where('kelas', $base->kelas->nama)->pluck('id');
@@ -371,7 +369,10 @@ class AbsensiController extends Controller
             );
         }
 
-        return redirect()->route('absensi.session', $base->id)->with('success', 'Sesi absensi dibuka');
+        return redirect()->route('absensi.session', $base->id)->with([
+            'success' => 'Sesi absensi dibuka',
+            'password' => $password,
+        ]);
     }
 
     public function endSession(Jadwal $jadwal)

--- a/resources/views/absensi/session.blade.php
+++ b/resources/views/absensi/session.blade.php
@@ -8,6 +8,9 @@
     <div class="alert alert-success">{{ session('success') }}</div>
 @endif
 @if($session && $session->status_sesi === 'open')
+    @if(session('password'))
+        <div class="alert alert-info">Password Sesi: <strong>{{ session('password') }}</strong></div>
+    @endif
     <form action="{{ route('absensi.session.end', $jadwal->id) }}" method="POST">
         @csrf
         <button class="btn btn-danger">Tutup Sesi</button>
@@ -15,13 +18,6 @@
 @else
     <form action="{{ route('absensi.session.start', $jadwal->id) }}" method="POST">
         @csrf
-        @if(! $session)
-            <div class="mb-3">
-                <label>Password</label>
-                <input type="password" name="password" class="form-control" required>
-                <x-input-error :messages="$errors->get('password')" class="mt-1" />
-            </div>
-        @endif
         <button class="btn btn-primary" {{ $canStart ? '' : 'disabled' }}>Mulai Sesi</button>
     </form>
 @endif


### PR DESCRIPTION
## Summary
- Automatically generate a random password when a teacher starts an attendance session
- Show the generated password on the session management page and remove manual password entry

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_6897a704f4e4832b9acf9692bd01a4af