### PR TITLE
Fix attendance session password mismatch for students

### DIFF
--- a/app/Http/Controllers/StudentController.php
+++ b/app/Http/Controllers/StudentController.php
@@ -172,6 +172,7 @@ class StudentController extends Controller
                     ->where('hari', $hari)
                     ->where('jam_mulai', '<=', $time);
             })
+            ->latest('id')
             ->first();
         if (! $session) {
             abort(403);


### PR DESCRIPTION
## Summary
- fetch the most recent open attendance session so check-in password validation uses the right record

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68980ef6d618832b83e1eeec5e72b80c