### PR TITLE
Add dropdown filters for penilaian search

### DIFF
--- a/app/Http/Controllers/PenilaianController.php
+++ b/app/Http/Controllers/PenilaianController.php
@@ -82,8 +82,17 @@ class PenilaianController extends Controller
             });
         }
 
+        $kelasList = Kelas::whereIn('nama', $this->kelasGuru())->pluck('nama');
+        if ($user && $user->role === 'guru') {
+            $guru = Guru::where('user_id', $user->id)->first();
+            $mapelIds = Pengajaran::where('guru_id', $guru?->id)->pluck('mapel_id')->unique();
+            $mapelList = MataPelajaran::whereIn('id', $mapelIds)->pluck('nama');
+        } else {
+            $mapelList = MataPelajaran::pluck('nama');
+        }
+
         $penilaian = $query->paginate(10)->withQueryString();
-        return view('penilaian.index', compact('penilaian', 'nama', 'kelas', 'mapel'));
+        return view('penilaian.index', compact('penilaian', 'nama', 'kelas', 'mapel', 'kelasList', 'mapelList'));
     }
 
     public function create()

--- a/resources/views/penilaian/index.blade.php
+++ b/resources/views/penilaian/index.blade.php
@@ -9,10 +9,20 @@
         <input type="text" name="nama" value="{{ request('nama') }}" class="form-control" placeholder="Nama Siswa">
     </div>
     <div class="col-md-3">
-        <input type="text" name="kelas" value="{{ request('kelas') }}" class="form-control" placeholder="Kelas">
+        <select name="kelas" class="form-select">
+            <option value="">Semua Kelas</option>
+            @foreach($kelasList as $k)
+                <option value="{{ $k }}" {{ request('kelas') == $k ? 'selected' : '' }}>{{ $k }}</option>
+            @endforeach
+        </select>
     </div>
     <div class="col-md-3">
-        <input type="text" name="mapel" value="{{ request('mapel') }}" class="form-control" placeholder="Mata Pelajaran">
+        <select name="mapel" class="form-select">
+            <option value="">Semua Mata Pelajaran</option>
+            @foreach($mapelList as $m)
+                <option value="{{ $m }}" {{ request('mapel') == $m ? 'selected' : '' }}>{{ $m }}</option>
+            @endforeach
+        </select>
     </div>
     <div class="col-md-3 d-flex">
         <button type="submit" class="btn btn-primary me-2">Cari</button>

--- a/tests/Feature/PenilaianSearchTest.php
+++ b/tests/Feature/PenilaianSearchTest.php
@@ -100,6 +100,6 @@ class PenilaianSearchTest extends TestCase
         $response = $this->get('/penilaian?mapel=Matematika');
         $response->assertOk();
         $response->assertSee('Matematika');
-        $response->assertDontSee('IPA');
+        $response->assertDontSee('<td>IPA</td>', false);
     }
 }


### PR DESCRIPTION
## Summary
- switch class and subject filters on penilaian index to dropdowns
- populate dropdown options in controller
- adjust penilaian search test for dropdown rendering

## Testing
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68981ba06af8832b93f656edc5d32817